### PR TITLE
Migrate 'additional calculations' to dim_monthly_zone_statistics

### DIFF
--- a/week_4_analytics_engineering/dbt-duckdb/models/core/dim_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/dbt-duckdb/models/core/dim_monthly_zone_revenue.sql
@@ -17,10 +17,5 @@ SELECT
     SUM(total_amount)           AS revenue_monthly_total_amount,
     SUM(congestion_surcharge)   AS revenue_monthly_congestion_surcharge,
 
-    -- Aditional Calculations
-    COUNT(trip_id)              AS total_monthly_trips,
-    AVG(passenger_count)        AS avg_montly_passenger_count,
-    AVG(trip_distance)          AS avg_montly_trip_distance
-
 FROM {{ ref('fact_yellow_green_trips') }}
 GROUP BY 1, 2, 3

--- a/week_4_analytics_engineering/dbt-duckdb/models/core/dim_monthly_zone_statistics.sql
+++ b/week_4_analytics_engineering/dbt-duckdb/models/core/dim_monthly_zone_statistics.sql
@@ -1,0 +1,15 @@
+{{ config(materialize='table')}}
+
+SELECT
+    -- Revenue Grouping
+    pickup_zone AS revenue_zone,
+    date_trunc('month', pickup_datetime) AS revenue_month,    
+    service_type,
+
+    -- Additional Calculations
+    COUNT(trip_id)        AS total_monthly_trips,
+    AVG(passenger_count)  AS avg_montly_passenger_count,
+    AVG(trip_distance)    AS avg_montly_trip_distance
+
+FROM {{ ref('fact_yellow_green_trips') }}
+GROUP BY 1, 2, 3


### PR DESCRIPTION
### Summary

* Remove the columns below from dim_monthly_zone_revenue:
  - 'total_monthly_trips',
  - 'avg_montly_passenger_count',
  - 'avg_montly_trip_distance'

* Add new dimension: dim_monthly_zone_statistics with the columns mentioned above

### Comparison Report 
<details>
<summary>Comparison Summary</summary>

Table | Rows | Columns 
--- | --- | ---
fact_fhv_trips | 17878276 (+621) | 13 (+0) 
dim_zone_lookup | 265 (+0) | 4 (+0) 
fact_yellow_green_trips | 61604290 (+4) | 26 (+0) 
dim_monthly_zone_statistics (+) | 12010 | 6 
dim_monthly_zone_revenue (!) | 12010 (+0) | 12 (-3)<br/>(deleted=3) 


</details>
<details>
<summary>Tables Summary (added=1, schema changed=1)</summary>
<blockquote>

<details>
<summary>fact_fhv_trips</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
dispatching_base_num | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
affiliated_base_num | VARCHAR | 100.0% (+0.0%) | 0.01% (-0.0%) 
pickup_location_id | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_borough | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_service_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_location_id | BIGINT | 100.0% (+0.0%) | 0.0% (+0.0%) 
dropoff_borough | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_service_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
shared_ride_flag | VARCHAR | 22.23% (+0.01%) | 0.0% (-0.0%) 
pickup_datetime | TIMESTAMP | 100.0% (+0.0%) | 28.04% (-0.0%) 
dropoff_datetime | TIMESTAMP | 100.0% (+0.0%) | 28.25% (-0.0%) 

</details>
<details>
<summary>dim_zone_lookup</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
location_id | BIGINT | 100.0% (+0.0%) | 100.0% (+0.0%) 
borough | VARCHAR | 100.0% (+0.0%) | 2.64% (+0.0%) 
zone | VARCHAR | 100.0% (+0.0%) | 98.87% (+0.0%) 
service_zone | VARCHAR | 100.0% (+0.0%) | 1.89% (+0.0%) 

</details>
<details>
<summary>fact_yellow_green_trips</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
trip_id | VARCHAR | 100.0% (+0.0%) | 92.18% (+0.0%) 
vendor_id | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
service_type | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
ratecode_id | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_location_id | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_borough | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_location_id | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_borough | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
dropoff_zone | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
pickup_datetime | TIMESTAMP | 100.0% (+0.0%) | 61.73% (+0.0%) 
dropoff_datetime | TIMESTAMP | 100.0% (+0.0%) | 53.57% (-0.0%) 
store_and_fwd_flag | VARCHAR | 100.0% (+0.0%) | 0.0% (-0.0%) 
passenger_count | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
trip_distance | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.01% (-0.0%) 
trip_type | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
fare_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.02% (-0.0%) 
extra | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.0% (-0.0%) 
mta_tax | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.0% (-0.0%) 
tip_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.01% (-0.0%) 
tolls_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.0% (-0.0%) 
ehail_fee | DOUBLE_PRECISION | 89.85% (-0.0%) | 0.0% (-0.0%) 
improvement_surcharge | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.0% (-0.0%) 
total_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 0.03% (-0.0%) 
payment_type | BIGINT | 100.0% (+0.0%) | 0.0% (-0.0%) 
congestion_surcharge | DOUBLE_PRECISION | 95.46% (-0.0%) | 0.0% (-0.0%) 

</details>
<details>
<summary>dim_monthly_zone_statistics (+)</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
revenue_zone (+) | VARCHAR | 100.0% | 2.16% 
revenue_month (+) | DATE | 100.0% | 0.45% 
service_type (+) | VARCHAR | 100.0% | 0.02% 
total_monthly_trips (+) | BIGINT | 100.0% | 27.84% 
avg_montly_passenger_count (+) | DOUBLE_PRECISION | 100.0% | 52.77% 
avg_montly_trip_distance (+) | DOUBLE_PRECISION | 100.0% | 95.75% 

</details>
<details>
<summary>dim_monthly_zone_revenue (!)</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
revenue_zone | VARCHAR | 100.0% (+0.0%) | 2.16% (+0.0%) 
revenue_month | DATE | 100.0% (+0.0%) | 0.45% (+0.0%) 
service_type | VARCHAR | 100.0% (+0.0%) | 0.02% (+0.0%) 
revenue_monthly_fare | DOUBLE_PRECISION | 100.0% (+0.0%) | 89.76% (-0.03%) 
revenue_monthly_extra | DOUBLE_PRECISION | 100.0% (+0.0%) | 31.06% (+0.02%) 
revenue_monthly_mta_tax | DOUBLE_PRECISION | 100.0% (+0.0%) | 28.09% (+0.0%) 
revenue_monthly_tip_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 74.03% (-0.18%) 
revenue_monthly_tolls_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 45.82% (+0.23%) 
revenue_monthly_ehail_fee | DOUBLE_PRECISION | 52.91% (+0.0%) | 0.05% (+0.0%) 
revenue_monthly_improvement_surcharge | DOUBLE_PRECISION | 100.0% (+0.0%) | 35.24% (-0.22%) 
revenue_monthly_total_amount | DOUBLE_PRECISION | 100.0% (+0.0%) | 96.84% (+0.04%) 
revenue_monthly_congestion_surcharge | DOUBLE_PRECISION | 98.83% (+0.0%) | 22.23% (+0.03%) 
total_monthly_trips (-) | ~~BIGINT~~ | - | - 
avg_montly_passenger_count (-) | ~~DOUBLE_PRECISION~~ | - | - 
avg_montly_trip_distance (-) | ~~DOUBLE_PRECISION~~ | - | - 

</details>
</blockquote></details>