### PR TITLE
Makefile / Single and Multi-broker Setup / Add Large Files to Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+week_6_stream_processing/kotlin/src/main/resources/yellow_tripdata_2019-01.csv.gz filter=lfs diff=lfs merge=lfs -text
+week_6_stream_processing/kotlin/src/main/resources/fhv_tripdata_2019-01.csv.gz filter=lfs diff=lfs merge=lfs -text
+week_6_stream_processing/kotlin/src/main/resources/green_tripdata_2019-01.csv.gz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -245,24 +245,20 @@ dbt_modules/
 dbt_packages/
 logs/
 
-### DataTalks Data Engineering Zoomcamp ###
+### Developer Workstation ###
 
-# Docker volume for PostgresSQL
-**/pgdata/**
-
-# Docker volume for pgAdmin
-**/pgadmin/**
-
-# Docker volume for Kafka and ZooKeeper
-**/confluent-data/**
+# Docker volumes for Kafka, ZooKeeper, PostgresSQL, pgAdmin
+**/volumes/**
 
 # Datasets
-**/*datasets/**
+**/datasets/**
+**/*.csv
+**/*.parquet
 
 # GCP Crendeitals
 **/credentials/**
 
-### macOS ###
+# macOS
 **/.DS_Store
 
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm,jupyternotebooks,visualstudiocode,terraform,dbt

--- a/week_1_basics_n_setup/postgres_ingest/docker-compose.yml
+++ b/week_1_basics_n_setup/postgres_ingest/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=ny_taxi
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - ./volumes/pgdata:/var/lib/postgresql/data
     ports:
       - "5433:5432"
     networks:
@@ -24,7 +24,7 @@ services:
       - PGADMIN_DEFAULT_PASSWORD=admin
       - PGADMIN_CONFIG_SERVER_MODE=False
     volumes:
-      - ./pgadmin:/var/lib/pgadmin
+      - ./volumes/pgadmin:/var/lib/pgadmin
     depends_on:
       - postgres
     ports:

--- a/week_6_stream_processing/Makefile
+++ b/week_6_stream_processing/Makefile
@@ -1,0 +1,14 @@
+.PHONY: dirs setup full-setup minimal-setup
+
+setup: minimal-setup
+
+full-setup: dirs
+	@docker-compose -f docker-compose.complex.yml up -d
+
+minimal-setup: dirs
+	@docker-compose -f docker-compose.simple.yml up -d
+
+dirs:
+	@mkdir -p volumes/confluent-{single-broker,multi-broker}/{zk-data,zk-txn-logs}
+	@mkdir -p volumes/confluent-single-broker/kafka_0
+	@mkdir -p volumes/confluent-multi-broker/kafka_{0,1,2}

--- a/week_6_stream_processing/README.md
+++ b/week_6_stream_processing/README.md
@@ -43,25 +43,17 @@ ksql>
 
 ### Developer Setup
 
-**Note for Windows Users**:
+**1.** Start up Kafka Cluster and external dependencies with:
 
-You'll have to ensure that `userid:1000`, `groupid:1000` have read/write permissions for the bind mounts setup on docker-compose.yml
-```shell
-mkdir -p confluent-data/zk-data
-mkdir -p confluent-data/zk-txn-logs
-mkdir -p confluent-data/kafka_0
-mkdir -p confluent-data/kafka_1
-mkdir -p confluent-data/kafka_2
-```
+1.1. For a single-broker setup, without Confluent REST-Proxy, run
 
 ```shell
-chown -R 1000:1000 confluent-data/
+make minimal-setup 
 ```
 
-
-**1.** Fire up the Confluent Platform and the UIs with:
-```
-docker-compose up -d
+1.2. Alternatively, for a multi-broker setup, with all features, run full-setup instead:
+```shell
+make full-setup
 ```
 
 **2.** Start up with the ksqlDB CLI

--- a/week_6_stream_processing/docker-compose.complex.yml
+++ b/week_6_stream_processing/docker-compose.complex.yml
@@ -1,0 +1,233 @@
+version: "3.9"
+services:
+  zookeeper:
+    container_name: cp-zookeeper
+    image: confluentinc/cp-zookeeper:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - ZOOKEEPER_CLIENT_PORT=2181
+      - ZOOKEEPER_TICK_TIME=2000
+      - ZOOKEEPER_SYNC_LIMIT=5
+    volumes:
+      - ./volumes/confluent-multi-broker/zk-data:/var/lib/zookeeper/data
+      - ./volumes/confluent-multi-broker/zk-txn-logs:/var/lib/zookeeper/log
+    ports:
+      - '2181:2181'
+    networks:
+      - sdn
+
+  kafka_0:
+    container_name: cp-kafka-0
+    image: confluentinc/cp-kafka:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENERS=INTERNAL://kafka_0:29090,EXTERNAL://:9090
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_0:29090,EXTERNAL://127.0.0.1:9090
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_DELETE_TOPIC_ENABLE=true
+    volumes:
+      - ./volumes/confluent-multi-broker/kafka_0:/var/lib/kafka/data
+    depends_on:
+      - zookeeper
+    ports:
+      - '9090:9090'
+    networks:
+      - sdn
+
+  kafka_1:
+    container_name: cp-kafka-1
+    image: confluentinc/cp-kafka:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - KAFKA_BROKER_ID=2
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENERS=INTERNAL://kafka_1:29091,EXTERNAL://:9091
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_1:29091,EXTERNAL://127.0.0.1:9091
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_DELETE_TOPIC_ENABLE=true
+    volumes:
+      - ./volumes/confluent-multi-broker/kafka_1:/var/lib/kafka/data
+    depends_on:
+      - zookeeper
+    ports:
+      - '9091:9091'
+    networks:
+      - sdn
+
+  kafka_2:
+    container_name: cp-kafka-2
+    image: confluentinc/cp-kafka:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - KAFKA_BROKER_ID=3
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENERS=INTERNAL://kafka_2:29092,EXTERNAL://:9092
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_2:29092,EXTERNAL://127.0.0.1:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_DELETE_TOPIC_ENABLE=true
+    volumes:
+      - ./volumes/confluent-multi-broker/kafka_2:/var/lib/kafka/data
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+    networks:
+      - sdn
+
+  ksqldb-server:
+    container_name: cp-ksqldb-server
+    image: confluentinc/cp-ksqldb-server:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      KSQL_LISTENERS: http://0.0.0.0:8088
+      KSQL_BOOTSTRAP_SERVERS: kafka_0:29090,kafka_1:29091,kafka_2:29092
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+    ports:
+      - '8088:8088'
+    networks:
+      - sdn
+
+  ksqldb-cli:
+    container_name: cp-ksqldb-cli
+    image: confluentinc/cp-ksqldb-cli:7.3.2
+    platform: linux/arm64
+    restart: always
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true
+    networks:
+      - sdn
+
+  schema-registry:
+    container_name: cp-schema-registry
+    image: confluentinc/cp-schema-registry:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka_0:29090,PLAINTEXT://kafka_1:29091,PLAINTEXT://kafka_2:29092
+      - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
+      - SCHEMA_REGISTRY_DEBUG=true
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+    ports:
+      - '8081:8081'
+    networks:
+      - sdn
+
+  rest-proxy:
+    container_name: cp-kafka-rest-proxy
+    image: confluentinc/cp-kafka-rest:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - KAFKA_REST_HOST_NAME=rest-proxy
+      - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka_0:29090,PLAINTEXT://kafka_1:29091,PLAINTEXT://kafka_2:29092
+      - KAFKA_REST_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - KAFKA_REST_LISTENERS=http://rest-proxy:8082
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+      - schema-registry
+    ports:
+      - '8082:8082'
+    networks:
+      - sdn
+
+  # Confluent Control Center Docs:
+  # - Comment out/Uncomment lines 174 to 199 to toggle Confluent Control Center on and off
+  # - https://docs.confluent.io/platform/current/control-center/installation/configure-control-center.html
+  # - https://docs.confluent.io/platform/current/control-center/installation/properties.html
+
+  control-center:
+    container_name: cp-control-center
+    image: confluentinc/cp-enterprise-control-center:7.3.2
+    platform: linux/arm64
+    restart: always
+    environment:
+      - CONTROL_CENTER_BOOTSTRAP_SERVERS=kafka_0:29090,kafka_1:29091,kafka_2:29092
+      - CONTROL_CENTER_ZOOKEEPER_CONNECT=zookeeper:2181
+      - CONTROL_CENTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - CONTROL_CENTER_KSQL_KSQLDB-SERVER-0_URL=http://ksqldb-server:8088
+      - CONTROL_CENTER_REPLICATION_FACTOR=1
+      - CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS=1
+      - CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS=1
+      - CONFLUENT_METRICS_TOPIC_REPLICATION=1
+      - PORT=9021
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+      - ksqldb-server
+      - schema-registry
+    ports:
+      - '9021:9021'
+    networks:
+      - sdn
+
+  # Conduktor Platform Docs:
+  # - https://docs.conduktor.io/platform/configuration/env-variables
+  # - https://docs.conduktor.io/platform/installation/hardware
+  conduktor-platform:
+    container_name: conduktor-platform
+    image: conduktor/conduktor-platform:1.12.1
+    platform: linux/arm64
+    restart: always
+    environment:
+      - CDK_CLUSTERS_0_ID=warp
+      - CDK_CLUSTERS_0_NAME=kafka-in-docker-cluster
+      - CDK_CLUSTERS_0_BOOTSTRAPSERVERS=kafka_0:29090,kafka_1:29091,kafka_2:29092
+      - CDK_CLUSTERS_0_SCHEMAREGISTRY_ID=warp-registry
+      - CDK_CLUSTERS_0_SCHEMAREGISTRY_URL=http://schema-registry:8081
+      - CDK_AUTH_LOCAL-USERS_0_EMAIL=admin@conduktor.io
+      - CDK_AUTH_LOCAL-USERS_0_PASSWORD=admin
+      - CDK_LISTENING_PORT=8080
+      - RUN_MODE=nano
+    depends_on:
+      - zookeeper
+      - kafka_0
+      - kafka_1
+      - kafka_2
+      - ksqldb-server
+      - schema-registry
+    ports:
+      - '8080:8080'
+    networks:
+      - sdn
+
+networks:
+  sdn:
+    name: stream-processing-network

--- a/week_6_stream_processing/docker-compose.simple.yml
+++ b/week_6_stream_processing/docker-compose.simple.yml
@@ -10,12 +10,12 @@ services:
       - ZOOKEEPER_TICK_TIME=2000
       - ZOOKEEPER_SYNC_LIMIT=5
     volumes:
-      - ./confluent-data/zk-data:/var/lib/zookeeper/data
-      - ./confluent-data/zk-txn-logs:/var/lib/zookeeper/log
+      - ./volumes/confluent-single-broker/zk-data:/var/lib/zookeeper/data
+      - ./volumes/confluent-single-broker/zk-txn-logs:/var/lib/zookeeper/log
     ports:
       - '2181:2181'
     networks:
-      - dspn
+      - sdn
 
   kafka_0:
     container_name: cp-kafka-0
@@ -33,61 +33,13 @@ services:
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
       - KAFKA_DELETE_TOPIC_ENABLE=true
     volumes:
-      - ./confluent-data/kafka_0:/var/lib/kafka/data
+      - ./volumes/confluent-single-broker/kafka_0:/var/lib/kafka/data
     depends_on:
       - zookeeper
     ports:
       - '9090:9090'
     networks:
-      - dspn
-
-  kafka_1:
-    container_name: cp-kafka-1
-    image: confluentinc/cp-kafka:7.3.2
-    platform: linux/arm64
-    restart: always
-    environment:
-      - KAFKA_BROKER_ID=2
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=INTERNAL://kafka_1:29091,EXTERNAL://:9091
-      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_1:29091,EXTERNAL://127.0.0.1:9091
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_DELETE_TOPIC_ENABLE=true
-    volumes:
-      - ./confluent-data/kafka_1:/var/lib/kafka/data
-    depends_on:
-      - zookeeper
-    ports:
-      - '9091:9091'
-    networks:
-      - dspn
-
-  kafka_2:
-    container_name: cp-kafka-2
-    image: confluentinc/cp-kafka:7.3.2
-    platform: linux/arm64
-    restart: always
-    environment:
-      - KAFKA_BROKER_ID=3
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=INTERNAL://kafka_2:29092,EXTERNAL://:9092
-      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_2:29092,EXTERNAL://127.0.0.1:9092
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_DELETE_TOPIC_ENABLE=true
-    volumes:
-      - ./confluent-data/kafka_2:/var/lib/kafka/data
-    depends_on:
-      - zookeeper
-    ports:
-      - '9092:9092'
-    networks:
-      - dspn
+      - sdn
 
   ksqldb-server:
     container_name: cp-ksqldb-server
@@ -102,12 +54,10 @@ services:
     depends_on:
       - zookeeper
       - kafka_0
-      - kafka_1
-      - kafka_2
     ports:
       - '8088:8088'
     networks:
-      - dspn
+      - sdn
 
   ksqldb-cli:
     container_name: cp-ksqldb-cli
@@ -117,13 +67,11 @@ services:
     depends_on:
       - zookeeper
       - kafka_0
-      - kafka_1
-      - kafka_2
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true
     networks:
-      - dspn
+      - sdn
 
   schema-registry:
     container_name: cp-schema-registry
@@ -132,39 +80,16 @@ services:
     restart: always
     environment:
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
-      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka_0:29090,PLAINTEXT://kafka_1:29091,PLAINTEXT://kafka_2:29092
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka_0:29090
       - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
       - SCHEMA_REGISTRY_DEBUG=true
     depends_on:
       - zookeeper
       - kafka_0
-      - kafka_1
-      - kafka_2
     ports:
       - '8081:8081'
     networks:
-      - dspn
-
-  rest-proxy:
-    container_name: cp-kafka-rest-proxy
-    image: confluentinc/cp-kafka-rest:7.3.2
-    platform: linux/arm64
-    restart: always
-    environment:
-      - KAFKA_REST_HOST_NAME=rest-proxy
-      - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka_0:29090,PLAINTEXT://kafka_1:29091,PLAINTEXT://kafka_2:29092
-      - KAFKA_REST_SCHEMA_REGISTRY_URL=http://schema-registry:8081
-      - KAFKA_REST_LISTENERS=http://rest-proxy:8082
-    depends_on:
-      - zookeeper
-      - kafka_0
-      - kafka_1
-      - kafka_2
-      - schema-registry
-    ports:
-      - '8082:8082'
-    networks:
-      - dspn
+      - sdn
 
   # Confluent Control Center Docs:
   # - Comment out/Uncomment lines 174 to 199 to toggle Confluent Control Center on and off
@@ -177,7 +102,7 @@ services:
     platform: linux/arm64
     restart: always
     environment:
-      - CONTROL_CENTER_BOOTSTRAP_SERVERS=kafka_0:29090,kafka_1:29091,kafka_2:29092
+      - CONTROL_CENTER_BOOTSTRAP_SERVERS=kafka_0:29090
       - CONTROL_CENTER_ZOOKEEPER_CONNECT=zookeeper:2181
       - CONTROL_CENTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
       - CONTROL_CENTER_KSQL_KSQLDB-SERVER-0_URL=http://ksqldb-server:8088
@@ -189,39 +114,12 @@ services:
     depends_on:
       - zookeeper
       - kafka_0
-      - kafka_1
-      - kafka_2
       - ksqldb-server
       - schema-registry
     ports:
       - '9021:9021'
     networks:
-      - dspn
-
-  # kpow Docs:
-  # - Comment out/Uncomment lines 205 to 224 to toggle Kpow on and off
-  # - https://docs.kpow.io/ce/configuration/
-
-  # kpow:
-  #   container_name: kpow
-  #   image: factorhouse/kpow-ce:91.1.1
-  #   platform: linux/arm64
-  #   restart: always
-  #   environment:
-  #     - BOOTSTRAP=kafka_0:29090,kafka_1:29091,kafka_2:29092
-  #     - SECURITY_PROTOCOL=PLAINTEXT
-  #     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
-  #   depends_on:
-  #     - zookeeper
-  #     - kafka_0
-  #     - kafka_1
-  #     - kafka_2
-  #     - ksqldb-server
-  #     - schema-registry
-  #   ports:
-  #     - '3000:3000'
-  #   networks:
-  #     - dspn
+      - sdn
 
   # Conduktor Platform Docs:
   # - https://docs.conduktor.io/platform/configuration/env-variables
@@ -233,7 +131,7 @@ services:
     environment:
       - CDK_CLUSTERS_0_ID=warp
       - CDK_CLUSTERS_0_NAME=kafka-in-docker-cluster
-      - CDK_CLUSTERS_0_BOOTSTRAPSERVERS=kafka_0:29090,kafka_1:29091,kafka_2:29092
+      - CDK_CLUSTERS_0_BOOTSTRAPSERVERS=kafka_0:29090
       - CDK_CLUSTERS_0_SCHEMAREGISTRY_ID=warp-registry
       - CDK_CLUSTERS_0_SCHEMAREGISTRY_URL=http://schema-registry:8081
       - CDK_AUTH_LOCAL-USERS_0_EMAIL=admin@conduktor.io
@@ -243,15 +141,13 @@ services:
     depends_on:
       - zookeeper
       - kafka_0
-      - kafka_1
-      - kafka_2
       - ksqldb-server
       - schema-registry
     ports:
       - '8080:8080'
     networks:
-      - dspn
+      - sdn
 
 networks:
-  dspn:
-    name: distributed-stream-processing-network
+  sdn:
+    name: stream-processing-network

--- a/week_6_stream_processing/kotlin/src/main/kotlin/club/datatalks/kafka/TaxiConsumer.kt
+++ b/week_6_stream_processing/kotlin/src/main/kotlin/club/datatalks/kafka/TaxiConsumer.kt
@@ -51,7 +51,7 @@ fun main() {
 
     /** Fhv Taxi Producer **/
 //    val fhvTaxiConsumer = FhvTaxiConsumer(
-//        kafkaTopic = "green_tripdata",
+//        kafkaTopic = "fhv_tripdata",
 //        consumerGroup = "default"
 //    )
 //    fhvTaxiConsumer.start()

--- a/week_6_stream_processing/kotlin/src/main/resources/fhv_tripdata_2019-01.csv.gz
+++ b/week_6_stream_processing/kotlin/src/main/resources/fhv_tripdata_2019-01.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77d7798584f532a43d0ee49e4dc65b9ce6eb5518315ae92727cdb491dfb39304
+size 234164685

--- a/week_6_stream_processing/kotlin/src/main/resources/green_tripdata_2019-01.csv.gz
+++ b/week_6_stream_processing/kotlin/src/main/resources/green_tripdata_2019-01.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9266c5e3299f5db52b5a830889225789a391bc088b2b08d42180c6b900597b12
+size 10625566

--- a/week_6_stream_processing/kotlin/src/main/resources/yellow_tripdata_2019-01.csv.gz
+++ b/week_6_stream_processing/kotlin/src/main/resources/yellow_tripdata_2019-01.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eb744065361b15c6c8652ca6e6068ce36a3edbd69e356045fec0f594beb68b0
+size 126896536


### PR DESCRIPTION
## Summary

* Rename 'docker-compose.yml' to 'docker-compose.complex.yml' for multi-broker setup

* Add 'docker-compose.simple.yml' for a single-broker setup without Confluent REST-Proxy

* Add Makefile with tasks for 'simple-setup' and 'full-setup', also creates the fold structure for both setups

* Add week_6_stream_processing large datasets to Git LFS, and fix .gitignore accordingly

* FIX: kafkaTopic to 'fhv_tripdata' from 'green_tripdata'

* Update week1/postgres_ingest/docker-compose.yml to also  use 'volumes/pgdata' and 'volumes/pgadmin'