### PR TITLE
fix/sqlfmt: Fix SQL statements for BigQuery, RedShift, ClickHouse and Postgres

### DIFF
--- a/week_4_analytics_engineering/bigquery/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_fhv_trips.sql
@@ -1,9 +1,9 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema=env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-WITH fhv_tripdata as (
-    SELECT
+with fhv_tripdata as (
+    select
         dispatching_base_num,
         affiliated_base_num,
         pickup_datetime,
@@ -11,35 +11,34 @@ WITH fhv_tripdata as (
         pickup_location_id,
         dropoff_location_id,
         shared_ride_flag,
-        row_number() OVER (PARTITION BY dispatching_base_num, pickup_datetime) as row_num
-    FROM
+        row_number() over (partition by dispatching_base_num, pickup_datetime) as row_num
+    from 
         {{ ref('stg_fhv_tripdata') }}
 ),
 
-lookup_zones AS (
-    SELECT * FROM {{ ref('dim_zone_lookup' )}} 
-    WHERE borough != 'Unknown'
+lookup_zones as (
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
 )
 
-SELECT
-    t.dispatching_base_num  as dispatching_base_num,
-    t.affiliated_base_num   as affiliated_base_num,
-    t.pickup_location_id    as pickup_location_id,
-    pickup.borough          as pickup_borough,
-    pickup.zone             as pickup_zone,
-    pickup.service_zone     as pickup_service_zone,
-    t.dropoff_location_id   as dropoff_location_id,
-    dropoff.borough         as dropoff_borough,
-    dropoff.zone            as dropoff_zone,
-    dropoff.service_zone    as dropoff_service_zone,
-    t.shared_ride_flag      as shared_ride_flag,
-    t.pickup_datetime       as pickup_datetime,
-    t.dropoff_datetime      as dropoff_datetime
-FROM 
+select
+    t.dispatching_base_num as dispatching_base_num,
+    t.affiliated_base_num  as affiliated_base_num,
+    t.pickup_location_id   as pickup_location_id,
+    pickup.borough         as pickup_borough,
+    pickup.zone            as pickup_zone,
+    pickup.service_zone    as pickup_service_zone,
+    t.dropoff_location_id  as dropoff_location_id,
+    dropoff.borough        as dropoff_borough,
+    dropoff.zone           as dropoff_zone,
+    dropoff.service_zone   as dropoff_service_zone,
+    t.shared_ride_flag     as shared_ride_flag,
+    t.pickup_datetime      as pickup_datetime,
+    t.dropoff_datetime     as dropoff_datetime
+from  
     fhv_tripdata t
-INNER JOIN lookup_zones pickup  
-    ON t.pickup_location_id  = pickup.location_id
-INNER JOIN lookup_zones dropoff 
-    ON t.dropoff_location_id = dropoff.location_id
-WHERE 
+inner join 
+    lookup_zones pickup  on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id
+where 
     t.row_num = 1

--- a/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
@@ -9,8 +9,6 @@ with green_tripdata as (
         g.*
     from 
         {{ ref('stg_green_tripdata') }} g
-    where 
-        vendor_id is not null
 ),
 
 yellow_tripdata as (
@@ -20,8 +18,6 @@ yellow_tripdata as (
         y.*
     from 
         {{ ref('stg_yellow_tripdata') }} y
-    where 
-        vendor_id is not null
 ),
 
 all_tripdata as (

--- a/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
@@ -1,70 +1,69 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema=env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-WITH green_tripdata as (
-    SELECT
-        row_number() OVER(PARTITION BY vendor_id, pickup_datetime) as row_num,
-        g.*, 
-        'green' as service_type
-    FROM
+with green_tripdata as (
+    select
+        row_number() over(partition by vendor_id, pickup_datetime) as row_num,
+        'green' as service_type,
+        g.*
+    from 
         {{ ref('stg_green_tripdata') }} g
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 yellow_tripdata as (
-    SELECT
-        row_number() OVER ( PARTITION BY vendor_id, pickup_datetime ) as row_num,
-        y.*, 
-        'yellow' as service_type
-    FROM
+    select
+        row_number() over (partition by vendor_id, pickup_datetime) as row_num,
+        'yellow' as service_type,
+        y.*
+    from 
         {{ ref('stg_yellow_tripdata') }} y
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 all_tripdata as (
-    SELECT * FROM green_tripdata WHERE row_num = 1
-    UNION ALL
-    SELECT * FROM yellow_tripdata WHERE row_num = 1
+    select * from green_tripdata where row_num = 1    
+    union all 
+    select * from yellow_tripdata where row_num = 1
 ),
 
 lookup_zones as (
-    SELECT * FROM {{ ref('dim_zone_lookup' )}}
-    WHERE borough != 'Unknown'
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
 )
 
-SELECT
-    t.trip_id                   as trip_id,
-    t.vendor_id                 as vendor_id,
-    t.service_type              as service_type,
-    t.ratecode_id               as ratecode_id,
-    t.pickup_location_id        as pickup_location_id,
-    pickup.borough              as pickup_borough,
-    pickup.zone                 as pickup_zone,
-    t.dropoff_location_id       as dropoff_location_id,
-    dropoff.borough             as dropoff_borough,
-    dropoff.zone                as dropoff_zone,
-    t.pickup_datetime           as pickup_datetime,
-    t.dropoff_datetime          as dropoff_datetime,
-    t.store_and_fwd_flag        as store_and_fwd_flag,
-    t.passenger_count           as passenger_count,
-    t.trip_distance             as trip_distance,
-    t.trip_type                 as trip_type,
-    t.fare_amount               as fare_amount,
-    t.extra                     as extra,
-    t.mta_tax                   as mta_tax,
-    t.tip_amount                as tip_amount,
-    t.tolls_amount              as tolls_amount,
-    t.ehail_fee                 as ehail_fee,
-    t.improvement_surcharge     as improvement_surcharge,
-    t.total_amount              as total_amount,
-    t.payment_type              as payment_type,
-    t.congestion_surcharge      as congestion_surcharge
-FROM 
+select
+    t.trip_id               as trip_id,
+    t.vendor_id             as vendor_id,
+    t.service_type          as service_type,
+    t.ratecode_id           as ratecode_id,
+    t.pickup_location_id    as pickup_location_id,
+    pickup.borough          as pickup_borough,
+    pickup.zone             as pickup_zone,
+    t.dropoff_location_id   as dropoff_location_id,
+    dropoff.borough         as dropoff_borough,
+    dropoff.zone            as dropoff_zone,
+    t.pickup_datetime       as pickup_datetime,
+    t.dropoff_datetime      as dropoff_datetime,
+    t.store_and_fwd_flag    as store_and_fwd_flag,
+    t.passenger_count       as passenger_count,
+    t.trip_distance         as trip_distance,
+    t.trip_type             as trip_type,
+    t.fare_amount           as fare_amount,
+    t.extra                 as extra,
+    t.mta_tax               as mta_tax,
+    t.tip_amount            as tip_amount,
+    t.tolls_amount          as tolls_amount,
+    t.ehail_fee             as ehail_fee,
+    t.improvement_surcharge as improvement_surcharge,
+    t.total_amount          as total_amount,
+    t.payment_type          as payment_type,
+    t.congestion_surcharge  as congestion_surcharge
+from 
     all_tripdata t
-INNER JOIN lookup_zones pickup  
-    ON t.pickup_location_id  = pickup.location_id
-INNER JOIN lookup_zones dropoff 
-    ON t.dropoff_location_id = dropoff.location_id
+inner join 
+    lookup_zones pickup on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id

--- a/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
@@ -7,4 +7,5 @@ select
     Borough      as borough,
     Zone         as zone,
     service_zone as service_zone
-from {{ ref('taxi_zone_lookup') }}
+from 
+    {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
@@ -1,11 +1,10 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema=env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-SELECT
-    LocationID      as location_id,
-    Borough         as borough,
-    Zone            as zone,
-    service_zone    as service_zone
-FROM
-    {{ ref('taxi_zone_lookup') }}
+select
+    LocationID   as location_id,
+    Borough      as borough,
+    Zone         as zone,
+    service_zone as service_zone
+from {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/bigquery/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/fct_monthly_zone_revenue.sql
@@ -1,25 +1,25 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema=env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-SELECT
+select
     -- Revenue Grouping
-    pickup_zone                             as revenue_zone,
-    DATE_TRUNC(pickup_datetime, MONTH)      as revenue_month,    
-    service_type                            as service_type,
+    pickup_zone                                  as zone,
+    service_type                                 as service_type,
+    {{ date_trunc("month", "pickup_datetime") }} as order_year,
     -- Revenue Calculations
-    ROUND(SUM(fare_amount), 2)              as revenue_monthly_fare,
-    ROUND(SUM(extra), 2)                    as revenue_monthly_extra,
-    ROUND(SUM(mta_tax), 2)                  as revenue_monthly_mta_tax,
-    ROUND(SUM(tip_amount), 2)               as revenue_monthly_tip_amount,
-    ROUND(SUM(tolls_amount), 2)             as revenue_monthly_tolls_amount,
-    ROUND(SUM(ehail_fee), 2)                as revenue_monthly_ehail_fee,
-    ROUND(SUM(improvement_surcharge), 2)    as revenue_monthly_improvement_surcharge,
-    ROUND(SUM(total_amount), 2)             as revenue_monthly_total_amount,
-    ROUND(SUM(congestion_surcharge), 2)     as revenue_monthly_congestion_surcharge,
-FROM 
+    round(sum(fare_amount), 2)                   as monthly_fare,
+    round(sum(extra), 2)                         as monthly_extra,
+    round(sum(mta_tax), 2)                       as monthly_mta_tax,
+    round(sum(tip_amount), 2)                    as monthly_tip_amount,
+    round(sum(tolls_amount), 2)                  as monthly_tolls_amount,
+    round(sum(ehail_fee), 2)                     as monthly_ehail_fee,
+    round(sum(improvement_surcharge), 2)         as monthly_improvement_surcharge,
+    round(sum(total_amount), 2)                  as monthly_total_amount,
+    round(sum(congestion_surcharge), 2)          as monthly_congestion_surcharge
+from 
     {{ ref('dim_yellow_green_trips') }}
-GROUP BY 
+group by 
     pickup_zone, 
-    date_trunc(pickup_datetime, MONTH), 
-    service_type
+    service_type,
+    {{ date_trunc("month", "pickup_datetime") }}

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
@@ -1,25 +1,23 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-SELECT
+select
     -- identifiers
-    {{ 
-        dbt_utils.generate_surrogate_key([
-            'dispatching_base_num',
-            'pickup_datetime'
-        ]) 
-    }}                      as trip_id,
-    dispatching_base_num    as dispatching_base_num,
-    Affiliated_base_number  as affiliated_base_num,
+    {{ dbt_utils.generate_surrogate_key([
+        'dispatching_base_num',
+        'pickup_datetime'
+    ]) }}                  as trip_id,
+    dispatching_base_num   as dispatching_base_num,
+    Affiliated_base_number as affiliated_base_num,
     -- pickup and dropoff timestamps
-    pickup_datetime         as pickup_datetime,
-    dropOff_datetime        as dropoff_datetime,
+    pickup_datetime        as pickup_datetime,
+    dropOff_datetime       as dropoff_datetime,
     -- trip info
-    PUlocationID            as pickup_location_id,
-    DOlocationID            as dropoff_location_id,
-    SR_Flag                 as shared_ride_flag
-FROM 
+    PUlocationID           as pickup_location_id,
+    DOlocationID           as dropoff_location_id,
+    SR_Flag                as shared_ride_flag
+from 
     {{ source('bq-raw-nyc-trip_record', 'ext_fhv') }}
 
 
@@ -27,5 +25,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
@@ -1,42 +1,40 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-SELECT
+select
     -- identifiers
-    {{ 
-        dbt_utils.generate_surrogate_key([
-            'VendorID',
-            'lpep_pickup_datetime'
-        ])
-    }}                      as trip_id,
-    VendorID                as vendor_id,
-    RatecodeID              as ratecode_id,
-    PULocationID            as pickup_location_id,
-    DOLocationID            as dropoff_location_id,
+    {{ dbt_utils.generate_surrogate_key([
+        'VendorID',
+        'lpep_pickup_datetime'
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    lpep_pickup_datetime    as pickup_datetime,
-    lpep_dropoff_datetime   as dropoff_datetime,
+    lpep_pickup_datetime  as pickup_datetime,
+    lpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    trip_type               as trip_type,
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    trip_type             as trip_type,
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    ehail_fee               as ehail_fee,
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    ehail_fee             as ehail_fee,
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM 
+    }}                    as payment_type_desc
+from 
     {{ source('bq-raw-nyc-trip_record', 'ext_green') }}
 
 
@@ -44,5 +42,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
@@ -36,7 +36,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('bq-raw-nyc-trip_record', 'ext_green') }}
-
+where
+    VendorID is not null
 
 -- Run as:
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
@@ -1,42 +1,40 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET'))
-}}
+    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+) }}
 
-SELECT
+select
     -- identifiers
-    {{
-        dbt_utils.generate_surrogate_key([
-            'VendorID', 
-            'tpep_pickup_datetime'
-        ])
-    }}                      as trip_id,
-    VendorID                as vendor_id,
-    RatecodeID              as ratecode_id,
-    PULocationID            as pickup_location_id,
-    DOLocationID            as dropoff_location_id,
+    {{ dbt_utils.generate_surrogate_key([
+        'VendorID', 
+        'tpep_pickup_datetime'
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    tpep_pickup_datetime    as pickup_datetime,
-    tpep_dropoff_datetime   as dropoff_datetime,
+    tpep_pickup_datetime  as pickup_datetime,
+    tpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    1                       as trip_type, -- yellow cabs are always street-hail
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    1                     as trip_type, -- yellow cabs are always street-hail
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    0                       as ehail_fee, -- it does not apply for yellow cabs
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    0                     as ehail_fee, -- it does not apply for yellow cabs
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM 
+    }}                    as payment_type_desc
+from 
     {{ source('bq-raw-nyc-trip_record', 'ext_yellow') }}
 
 
@@ -44,5 +42,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
@@ -36,7 +36,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('bq-raw-nyc-trip_record', 'ext_yellow') }}
-
+where
+    VendorID is not null
 
 -- Run as:
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
@@ -1,71 +1,70 @@
 {{ config(
     schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table')
-}}
+    materialized='table'
+) }}
 
-WITH green_tripdata as (
-    SELECT
-        row_number() OVER(PARTITION BY vendor_id, pickup_datetime) as row_num,
-        g.*, 
-        'green' as service_type
-    FROM
+with green_tripdata as (
+    select
+        row_number() over(partition by vendor_id, pickup_datetime) as row_num,
+        'green' as service_type,
+        g.*
+    from 
         {{ ref('stg_green_tripdata') }} g
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 yellow_tripdata as (
-    SELECT
-        row_number() OVER ( PARTITION BY vendor_id, pickup_datetime ) as row_num,
-        y.*, 
-        'yellow' as service_type
-    FROM
+    select
+        row_number() over (partition by vendor_id, pickup_datetime) as row_num,
+        'yellow' as service_type,
+        y.*
+    from 
         {{ ref('stg_yellow_tripdata') }} y
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 all_tripdata as (
-    SELECT * FROM green_tripdata WHERE row_num = 1
-    UNION ALL
-    SELECT * FROM yellow_tripdata WHERE row_num = 1
+    select * from green_tripdata where row_num = 1    
+    union all 
+    select * from yellow_tripdata where row_num = 1
 ),
 
 lookup_zones as (
-    SELECT * FROM {{ ref('dim_zone_lookup' )}}
-    WHERE borough != 'Unknown'
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
 )
 
-
-SELECT
-    t.vendor_id                                 as vendor_id,
-    t.service_type                              as service_type,
-    t.ratecode_id                               as ratecode_id,
-    t.pickup_location_id                        as pickup_location_id,
-    pickup.borough                              as pickup_borough,
-    pickup.zone                                 as pickup_zone,
-    t.dropoff_location_id                       as dropoff_location_id,
-    dropoff.borough                             as dropoff_borough,
-    dropoff.zone                                as dropoff_zone,
-    t.pickup_datetime                           as pickup_datetime,
-    t.dropoff_datetime                          as dropoff_datetime,
-    t.store_and_fwd_flag                        as store_and_fwd_flag,
-    t.passenger_count                           as passenger_count,
-    t.trip_distance                             as trip_distance,
-    t.trip_type                                 as trip_type,
-    t.fare_amount                               as fare_amount,
-    t.extra                                     as extra,
-    t.mta_tax                                   as mta_tax,
-    t.tip_amount                                as tip_amount,
-    t.tolls_amount                              as tolls_amount,
-    t.ehail_fee                                 as ehail_fee,
-    t.improvement_surcharge                     as improvement_surcharge,
-    t.congestion_surcharge                      as congestion_surcharge,
-    t.total_amount                              as total_amount,
-    t.payment_type                              as payment_type
-FROM 
-    yellow_tripdata t
-INNER JOIN lookup_zones pickup  
-    ON t.pickup_location_id  = pickup.location_id
-INNER JOIN lookup_zones dropoff 
-    ON t.dropoff_location_id = dropoff.location_id
+select
+    t.trip_id               as trip_id,
+    t.vendor_id             as vendor_id,
+    t.service_type          as service_type,
+    t.ratecode_id           as ratecode_id,
+    t.pickup_location_id    as pickup_location_id,
+    pickup.borough          as pickup_borough,
+    pickup.zone             as pickup_zone,
+    t.dropoff_location_id   as dropoff_location_id,
+    dropoff.borough         as dropoff_borough,
+    dropoff.zone            as dropoff_zone,
+    t.pickup_datetime       as pickup_datetime,
+    t.dropoff_datetime      as dropoff_datetime,
+    t.store_and_fwd_flag    as store_and_fwd_flag,
+    t.passenger_count       as passenger_count,
+    t.trip_distance         as trip_distance,
+    t.trip_type             as trip_type,
+    t.fare_amount           as fare_amount,
+    t.extra                 as extra,
+    t.mta_tax               as mta_tax,
+    t.tip_amount            as tip_amount,
+    t.tolls_amount          as tolls_amount,
+    t.ehail_fee             as ehail_fee,
+    t.improvement_surcharge as improvement_surcharge,
+    t.total_amount          as total_amount,
+    t.payment_type          as payment_type,
+    t.congestion_surcharge  as congestion_surcharge
+from 
+    all_tripdata t
+inner join 
+    lookup_zones pickup on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table'
+    schema=env_var('DBT_CLICKHOUSE_SCHEMA')
 ) }}
 
 with green_tripdata as (
@@ -10,8 +9,6 @@ with green_tripdata as (
         g.*
     from 
         {{ ref('stg_green_tripdata') }} g
-    where 
-        vendor_id is not null
 ),
 
 yellow_tripdata as (
@@ -21,8 +18,6 @@ yellow_tripdata as (
         y.*
     from 
         {{ ref('stg_yellow_tripdata') }} y
-    where 
-        vendor_id is not null
 ),
 
 all_tripdata as (

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
@@ -1,12 +1,12 @@
 {{ config(
     schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table')
-}}
+    materialized='table'
+) }}
 
-SELECT
-    LocationID      as location_id,
-    Borough         as borough,
-    Zone            as zone,
-    service_zone    as service_zone
-FROM
+select
+    LocationID   as location_id,
+    Borough      as borough,
+    Zone         as zone,
+    service_zone as service_zone
+from 
     {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table'
+    schema=env_var('DBT_CLICKHOUSE_SCHEMA')
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
@@ -1,26 +1,26 @@
 {{ config(
     schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table')
-}}
+    materialized='table'
+) }}
 
-SELECT
+select
     -- Revenue Grouping
-    pickup_zone                           as revenue_zone,
-    date_trunc('month', pickup_datetime)  as revenue_month,
-    service_type                          as service_type,
+    pickup_zone                                  as zone,
+    service_type                                 as service_type,
+    {{ date_trunc("month", "pickup_datetime") }} as order_year,
     -- Revenue Calculations
-    ROUND(SUM(fare_amount), 2)             as revenue_monthly_fare,
-    ROUND(SUM(extra), 2)                   as revenue_monthly_extra,
-    ROUND(SUM(mta_tax), 2)                 as revenue_monthly_mta_tax,
-    ROUND(SUM(tip_amount), 2)              as revenue_monthly_tip_amount,
-    ROUND(SUM(tolls_amount), 2)            as revenue_monthly_tolls_amount,
-    ROUND(SUM(ehail_fee), 2)               as revenue_monthly_ehail_fee,
-    ROUND(SUM(improvement_surcharge), 2)   as revenue_monthly_improvement_surcharge,
-    ROUND(SUM(total_amount), 2)            as revenue_monthly_total_amount,
-    ROUND(SUM(congestion_surcharge), 2)    as revenue_monthly_congestion_surcharge
-FROM
+    round(sum(fare_amount), 2)                   as monthly_fare,
+    round(sum(extra), 2)                         as monthly_extra,
+    round(sum(mta_tax), 2)                       as monthly_mta_tax,
+    round(sum(tip_amount), 2)                    as monthly_tip_amount,
+    round(sum(tolls_amount), 2)                  as monthly_tolls_amount,
+    round(sum(ehail_fee), 2)                     as monthly_ehail_fee,
+    round(sum(improvement_surcharge), 2)         as monthly_improvement_surcharge,
+    round(sum(total_amount), 2)                  as monthly_total_amount,
+    round(sum(congestion_surcharge), 2)          as monthly_congestion_surcharge
+from 
     {{ ref('dim_yellow_green_trips') }}
-GROUP BY
-    pickup_zone,
-    date_trunc('month', pickup_datetime),
-    service_type
+group by 
+    pickup_zone, 
+    service_type,
+    {{ date_trunc("month", "pickup_datetime") }}

--- a/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema=env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table'
+    schema=env_var('DBT_CLICKHOUSE_SCHEMA')
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/staging/sources.yml
+++ b/week_4_analytics_engineering/clickhouse/models/staging/sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: postgres-raw-nyc-trip_record
+  - name: clickhouse-raw-nyc-trip_record
     schema: "{{ env_var('DBT_CLICKHOUSE_FQ_PGDATA_SCHEMA') }}"
     tables:
       - name: ntl_yellow_taxi

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
@@ -1,43 +1,49 @@
 {{ config(
     schema='stg_' ~ env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table')
-}}
+    materialized='table'
+) }}
 
-SELECT
+select
     -- identifiers
-    toInt8(vendorid)                        as vendor_id,
-    toInt8(ratecodeid)                      as ratecode_id,
-    toInt16(pulocationid)                   as pickup_location_id,
-    toInt16(dolocationid)                   as dropoff_location_id,
+    {{ dbt_utils.generate_surrogate_key([
+        'vendorid', 
+        'lpep_pickup_datetime'
+    ]) }}                                  as trip_id,
+    toInt8(vendorid)                       as vendor_id,
+    toInt8(ratecodeid)                     as ratecode_id,
+    toInt16(pulocationid)                  as pickup_location_id,
+    toInt16(dolocationid)                  as dropoff_location_id,
     -- pickup and dropoff timestamps
-    toDateTime(lpep_pickup_datetime)        as pickup_datetime,
-    toDateTime(lpep_dropoff_datetime)       as dropoff_datetime,
+    toDateTime(lpep_pickup_datetime)       as pickup_datetime,
+    toDateTime(lpep_dropoff_datetime)      as dropoff_datetime,
     -- trip info
-    toFixedString(store_and_fwd_flag, 1)    as store_and_fwd_flag,
-    toInt8(passenger_count)                 as passenger_count,
-    toDecimal32(trip_distance, 2)           as trip_distance,
-    toInt8(trip_type)                       as trip_type,
+    toFixedString(store_and_fwd_flag, 1)   as store_and_fwd_flag,
+    toInt8(passenger_count)                as passenger_count,
+    toDecimal32(trip_distance, 2)          as trip_distance,
+    toInt8(trip_type)                      as trip_type,
     -- payment info
-    toDecimal256(fare_amount, 8)            as fare_amount,
-    toDecimal256(extra, 8)                  as extra,
-    toDecimal256(mta_tax, 8)                as mta_tax,
-    toDecimal256(tip_amount, 8)             as tip_amount,
-    toDecimal256(tolls_amount, 8)           as tolls_amount,
-    toDecimal256(ehail_fee, 8)              as ehail_fee,
-    toDecimal256(improvement_surcharge, 8)  as improvement_surcharge,
-    toDecimal256(congestion_surcharge, 8)   as congestion_surcharge,
-    toDecimal256(total_amount, 8)           as total_amount,
-    payment_type                            as payment_type,
+    toDecimal256(fare_amount, 8)           as fare_amount,
+    toDecimal256(extra, 8)                 as extra,
+    toDecimal256(mta_tax, 8)               as mta_tax,
+    toDecimal256(tip_amount, 8)            as tip_amount,
+    toDecimal256(tolls_amount, 8)          as tolls_amount,
+    toDecimal256(ehail_fee, 8)             as ehail_fee,
+    toDecimal256(improvement_surcharge, 8) as improvement_surcharge,
+    toDecimal256(congestion_surcharge, 8)  as congestion_surcharge,
+    toDecimal256(total_amount, 8)          as total_amount,
+    payment_type                           as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                                      as payment_type_desc
-FROM 
-    {{ source('postgres-raw-nyc-trip_record', 'ntl_green_taxi') }}
+    }}                                     as payment_type_desc
+from 
+    {{ source('clickhouse-raw-nyc-trip_record', 'ntl_green_taxi') }}
+where
+    vendorid is not null
 
 
 -- Run as:
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
@@ -1,43 +1,49 @@
 {{ config(
     schema='stg_' ~ env_var('DBT_CLICKHOUSE_SCHEMA'),
-    materialized='table')
-}}
+    materialized='table'
+) }}
 
-SELECT
+select
     -- identifiers
-    toInt8(vendorid)                        as vendor_id,
-    toInt8(ratecodeid)                      as ratecode_id,
-    toInt16(pulocationid)                   as pickup_location_id,
-    toInt16(dolocationid)                   as dropoff_location_id,
-    -- pickup and dropoff timestamps
-    toDateTime(tpep_pickup_datetime)        as pickup_datetime,
-    toDateTime(tpep_dropoff_datetime)       as dropoff_datetime,
+    {{ dbt_utils.generate_surrogate_key([
+        'vendorid', 
+        'tpep_pickup_datetime'
+    ]) }}                                  as trip_id,
+    toInt8(vendorid)                       as vendor_id,
+    toInt8(ratecodeid)                     as ratecode_id,
+    toInt16(pulocationid)                  as pickup_location_id,
+    toInt16(dolocationid)                  as dropoff_location_id,
+    -- pickup and dropoff timestamp
+    toDateTime(tpep_pickup_datetime)       as pickup_datetime,
+    toDateTime(tpep_dropoff_datetime)      as dropoff_datetime,
     -- trip info
-    toFixedString(store_and_fwd_flag, 1)    as store_and_fwd_flag,
-    toInt8(passenger_count)                 as passenger_count,
-    toDecimal32(trip_distance, 2)           as trip_distance,
-    toInt8(1)                               as trip_type, -- yellow cabs are always street-hail
+    toFixedString(store_and_fwd_flag, 1)   as store_and_fwd_flag,
+    toInt8(passenger_count)                as passenger_count,
+    toDecimal32(trip_distance, 2)          as trip_distance,
+    toInt8(1)                              as trip_type, -- yellow cabs are always street-hail
     -- payment info
-    toDecimal256(fare_amount, 8)            as fare_amount,
-    toDecimal256(extra, 8)                  as extra,
-    toDecimal256(mta_tax, 8)                as mta_tax,
-    toDecimal256(tip_amount, 8)             as tip_amount,
-    toDecimal256(tolls_amount, 8)           as tolls_amount,
-    toDecimal256(0, 8)                      as ehail_fee, -- it does not apply for yellow cabs
-    toDecimal256(improvement_surcharge, 8)  as improvement_surcharge,
-    toDecimal256(congestion_surcharge, 8)   as congestion_surcharge,
-    toDecimal256(total_amount, 8)           as total_amount,
-    toDecimal256(payment_type, 8)           as payment_type,
+    toDecimal256(fare_amount, 8)           as fare_amount,
+    toDecimal256(extra, 8)                 as extra,
+    toDecimal256(mta_tax, 8)               as mta_tax,
+    toDecimal256(tip_amount, 8)            as tip_amount,
+    toDecimal256(tolls_amount, 8)          as tolls_amount,
+    toDecimal256(0, 8)                     as ehail_fee, -- it does not apply for yellow cabs
+    toDecimal256(improvement_surcharge, 8) as improvement_surcharge,
+    toDecimal256(congestion_surcharge, 8)  as congestion_surcharge,
+    toDecimal256(total_amount, 8)          as total_amount,
+    toDecimal256(payment_type, 8)          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                                      as payment_type_desc
-FROM 
-    {{ source('postgres-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
+    }}                                     as payment_type_desc
+from 
+    {{ source('clickhouse-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
+where
+    vendorid is not null
 
 
 -- Run as:
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 1000
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/postgres/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/postgres/models/core/dim_yellow_green_trips.sql
@@ -9,8 +9,6 @@ with green_tripdata as (
         g.*
     from 
         {{ ref('stg_green_tripdata') }} g
-    where 
-        vendor_id is not null
 ),
 
 yellow_tripdata as (
@@ -20,8 +18,6 @@ yellow_tripdata as (
         y.*
     from 
         {{ ref('stg_yellow_tripdata') }} y
-    where 
-        vendor_id is not null
 ),
 
 all_tripdata as (

--- a/week_4_analytics_engineering/postgres/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/postgres/models/core/dim_zone_lookup.sql
@@ -1,11 +1,11 @@
 {{ config(
-    schema=env_var('DBT_POSTGRES_SCHEMA'))
-}}
+    schema=env_var('DBT_POSTGRES_SCHEMA')
+) }}
 
-SELECT
-    locationid      as location_id,
-    borough         as borough,
-    zone            as zone,
-    service_zone    as service_zone
-FROM
+select
+    LocationID   as location_id,
+    Borough      as borough,
+    Zone         as zone,
+    service_zone as service_zone
+from 
     {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/postgres/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/postgres/models/core/fct_monthly_zone_revenue.sql
@@ -1,25 +1,25 @@
 {{ config(
-    schema=env_var('DBT_POSTGRES_SCHEMA'))
-}}
+    schema=env_var('DBT_POSTGRES_SCHEMA')
+) }}
 
-SELECT
+select
     -- Revenue Grouping
-    pickup_zone                           as revenue_zone,
-    date_trunc('month', pickup_datetime)  as revenue_month,
-    service_type                          as service_type,
+    pickup_zone                                  as zone,
+    service_type                                 as service_type,
+    {{ date_trunc("month", "pickup_datetime") }} as order_year,
     -- Revenue Calculations
-    ROUND(SUM(fare_amount), 2)             as revenue_monthly_fare,
-    ROUND(SUM(extra), 2)                   as revenue_monthly_extra,
-    ROUND(SUM(mta_tax), 2)                 as revenue_monthly_mta_tax,
-    ROUND(SUM(tip_amount), 2)              as revenue_monthly_tip_amount,
-    ROUND(SUM(tolls_amount), 2)            as revenue_monthly_tolls_amount,
-    ROUND(SUM(ehail_fee), 2)               as revenue_monthly_ehail_fee,
-    ROUND(SUM(improvement_surcharge), 2)   as revenue_monthly_improvement_surcharge,
-    ROUND(SUM(total_amount), 2)            as revenue_monthly_total_amount,
-    ROUND(SUM(congestion_surcharge), 2)    as revenue_monthly_congestion_surcharge
-FROM
+    round(sum(fare_amount), 2)                   as monthly_fare,
+    round(sum(extra), 2)                         as monthly_extra,
+    round(sum(mta_tax), 2)                       as monthly_mta_tax,
+    round(sum(tip_amount), 2)                    as monthly_tip_amount,
+    round(sum(tolls_amount), 2)                  as monthly_tolls_amount,
+    round(sum(ehail_fee), 2)                     as monthly_ehail_fee,
+    round(sum(improvement_surcharge), 2)         as monthly_improvement_surcharge,
+    round(sum(total_amount), 2)                  as monthly_total_amount,
+    round(sum(congestion_surcharge), 2)          as monthly_congestion_surcharge
+from 
     {{ ref('dim_yellow_green_trips') }}
-GROUP BY
-    pickup_zone,
-    date_trunc('month', pickup_datetime),
-    service_type
+group by 
+    pickup_zone, 
+    service_type,
+    {{ date_trunc("month", "pickup_datetime") }}

--- a/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
@@ -2,41 +2,39 @@
     schema='stg_' ~ env_var('DBT_POSTGRES_SCHEMA'))
 }}
 
-SELECT
+select
     -- identifiers
-    {{ 
-        dbt_utils.generate_surrogate_key([
-            'vendorid',
-            'lpep_pickup_datetime'
-        ])
-    }}                      as trip_id,
-    vendorid                as vendor_id,
-    ratecodeid              as ratecode_id,
-    pulocationid            as pickup_location_id,
-    dolocationid            as dropoff_location_id,
+    {{ dbt_utils.generate_surrogate_key([
+        'VendorID',
+        'lpep_pickup_datetime'
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    lpep_pickup_datetime    as pickup_datetime,
-    lpep_dropoff_datetime   as dropoff_datetime,
+    lpep_pickup_datetime  as pickup_datetime,
+    lpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    trip_type               as trip_type,
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    trip_type             as trip_type,
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    ehail_fee               as ehail_fee,
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    ehail_fee             as ehail_fee,
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM 
+    }}                    as payment_type_desc
+from 
     {{ source('pg-raw-nyc-trip_record', 'ntl_green_taxi') }}
 
 
@@ -44,5 +42,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
@@ -5,10 +5,10 @@
 select
     -- identifiers
     {{ dbt_utils.generate_surrogate_key([
-        'VendorID',
+        'vendorid',
         'lpep_pickup_datetime'
     ]) }}                 as trip_id,
-    VendorID              as vendor_id,
+    vendorid              as vendor_id,
     RatecodeID            as ratecode_id,
     PULocationID          as pickup_location_id,
     DOLocationID          as dropoff_location_id,
@@ -36,6 +36,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('pg-raw-nyc-trip_record', 'ntl_green_taxi') }}
+where
+    vendorid is not null
 
 
 -- Run as:

--- a/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
@@ -5,10 +5,10 @@
 select
     -- identifiers
     {{ dbt_utils.generate_surrogate_key([
-        'VendorID', 
+        'vendorid', 
         'tpep_pickup_datetime'
     ]) }}                 as trip_id,
-    VendorID              as vendor_id,
+    vendorid              as vendor_id,
     RatecodeID            as ratecode_id,
     PULocationID          as pickup_location_id,
     DOLocationID          as dropoff_location_id,
@@ -36,6 +36,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('pg-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
+where
+    vendorid is not null
 
 
 -- Run as:

--- a/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
@@ -2,41 +2,39 @@
     schema='stg_' ~ env_var('DBT_POSTGRES_SCHEMA'))
 }}
 
-SELECT
+select
     -- identifiers
-    {{
-        dbt_utils.generate_surrogate_key([
-            'vendorid', 
-            'tpep_pickup_datetime'
-        ])
-    }}                      as trip_id,
-    vendorid                as vendor_id,
-    ratecodeid              as ratecode_id,
-    pulocationid            as pickup_location_id,
-    dolocationid            as dropoff_location_id,
+    {{ dbt_utils.generate_surrogate_key([
+        'VendorID', 
+        'tpep_pickup_datetime'
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    tpep_pickup_datetime    as pickup_datetime,
-    tpep_dropoff_datetime   as dropoff_datetime,
+    tpep_pickup_datetime  as pickup_datetime,
+    tpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    1                       as trip_type, -- yellow cabs are always street-hail
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    1                     as trip_type, -- yellow cabs are always street-hail
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    0                       as ehail_fee, -- it does not apply for yellow cabs
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    0                     as ehail_fee, -- it does not apply for yellow cabs
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM 
+    }}                    as payment_type_desc
+from 
     {{ source('pg-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
 
 
@@ -44,5 +42,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/redshift/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_fhv_trips.sql
@@ -2,8 +2,8 @@
     schema=env_var('DBT_REDSHIFT_SCHEMA')
 ) }}
 
-WITH fhv_tripdata as (
-    SELECT
+with fhv_tripdata as (
+    select
         dispatching_base_num,
         affiliated_base_num,
         pickup_datetime,
@@ -11,35 +11,34 @@ WITH fhv_tripdata as (
         pickup_location_id,
         dropoff_location_id,
         shared_ride_flag,
-        row_number() OVER (PARTITION BY dispatching_base_num, pickup_datetime) as row_num
-    FROM
+        row_number() over (partition by dispatching_base_num, pickup_datetime) as row_num
+    from 
         {{ ref('stg_fhv_tripdata') }}
 ),
 
-lookup_zones AS (
-    SELECT * FROM {{ ref('dim_zone_lookup' )}} 
-    WHERE borough != 'Unknown'
+lookup_zones as (
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
 )
 
-SELECT
-    t.dispatching_base_num  as dispatching_base_num,
-    t.affiliated_base_num   as affiliated_base_num,
-    t.pickup_location_id    as pickup_location_id,
-    pickup.borough          as pickup_borough,
-    pickup.zone             as pickup_zone,
-    pickup.service_zone     as pickup_service_zone,
-    t.dropoff_location_id   as dropoff_location_id,
-    dropoff.borough         as dropoff_borough,
-    dropoff.zone            as dropoff_zone,
-    dropoff.service_zone    as dropoff_service_zone,
-    t.shared_ride_flag      as shared_ride_flag,
-    t.pickup_datetime       as pickup_datetime,
-    t.dropoff_datetime      as dropoff_datetime
-FROM 
+select
+    t.dispatching_base_num as dispatching_base_num,
+    t.affiliated_base_num  as affiliated_base_num,
+    t.pickup_location_id   as pickup_location_id,
+    pickup.borough         as pickup_borough,
+    pickup.zone            as pickup_zone,
+    pickup.service_zone    as pickup_service_zone,
+    t.dropoff_location_id  as dropoff_location_id,
+    dropoff.borough        as dropoff_borough,
+    dropoff.zone           as dropoff_zone,
+    dropoff.service_zone   as dropoff_service_zone,
+    t.shared_ride_flag     as shared_ride_flag,
+    t.pickup_datetime      as pickup_datetime,
+    t.dropoff_datetime     as dropoff_datetime
+from  
     fhv_tripdata t
-INNER JOIN lookup_zones pickup  
-    ON t.pickup_location_id  = pickup.location_id
-INNER JOIN lookup_zones dropoff 
-    ON t.dropoff_location_id = dropoff.location_id
-WHERE 
+inner join 
+    lookup_zones pickup  on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id
+where 
     t.row_num = 1

--- a/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
@@ -9,8 +9,6 @@ with green_tripdata as (
         g.*
     from 
         {{ ref('stg_green_tripdata') }} g
-    where 
-        vendor_id is not null
 ),
 
 yellow_tripdata as (
@@ -20,8 +18,6 @@ yellow_tripdata as (
         y.*
     from 
         {{ ref('stg_yellow_tripdata') }} y
-    where 
-        vendor_id is not null
 ),
 
 all_tripdata as (

--- a/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
@@ -2,69 +2,68 @@
     schema=env_var('DBT_REDSHIFT_SCHEMA')
 ) }}
 
-WITH green_tripdata as (
-    SELECT
-        row_number() OVER(PARTITION BY vendor_id, pickup_datetime) as row_num,
-        g.*, 
-        'green' as service_type
-    FROM
+with green_tripdata as (
+    select
+        row_number() over(partition by vendor_id, pickup_datetime) as row_num,
+        'green' as service_type,
+        g.*
+    from 
         {{ ref('stg_green_tripdata') }} g
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 yellow_tripdata as (
-    SELECT
-        row_number() OVER ( PARTITION BY vendor_id, pickup_datetime ) as row_num,
-        y.*, 
-        'yellow' as service_type
-    FROM
+    select
+        row_number() over (partition by vendor_id, pickup_datetime) as row_num,
+        'yellow' as service_type,
+        y.*
+    from 
         {{ ref('stg_yellow_tripdata') }} y
-    WHERE
-        vendor_id IS NOT NULL
+    where 
+        vendor_id is not null
 ),
 
 all_tripdata as (
-    SELECT * FROM green_tripdata WHERE row_num = 1
-    UNION ALL
-    SELECT * FROM yellow_tripdata WHERE row_num = 1
+    select * from green_tripdata where row_num = 1    
+    union all 
+    select * from yellow_tripdata where row_num = 1
 ),
 
 lookup_zones as (
-    SELECT * FROM {{ ref('dim_zone_lookup' )}}
-    WHERE borough != 'Unknown'
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
 )
 
-SELECT
-    t.trip_id                   as trip_id,
-    t.vendor_id                 as vendor_id,
-    t.service_type              as service_type,
-    t.ratecode_id               as ratecode_id,
-    t.pickup_location_id        as pickup_location_id,
-    pickup.borough              as pickup_borough,
-    pickup.zone                 as pickup_zone,
-    t.dropoff_location_id       as dropoff_location_id,
-    dropoff.borough             as dropoff_borough,
-    dropoff.zone                as dropoff_zone,
-    t.pickup_datetime           as pickup_datetime,
-    t.dropoff_datetime          as dropoff_datetime,
-    t.store_and_fwd_flag        as store_and_fwd_flag,
-    t.passenger_count           as passenger_count,
-    t.trip_distance             as trip_distance,
-    t.trip_type                 as trip_type,
-    t.fare_amount               as fare_amount,
-    t.extra                     as extra,
-    t.mta_tax                   as mta_tax,
-    t.tip_amount                as tip_amount,
-    t.tolls_amount              as tolls_amount,
-    t.ehail_fee                 as ehail_fee,
-    t.improvement_surcharge     as improvement_surcharge,
-    t.total_amount              as total_amount,
-    t.payment_type              as payment_type,
-    t.congestion_surcharge      as congestion_surcharge
-FROM 
+select
+    t.trip_id               as trip_id,
+    t.vendor_id             as vendor_id,
+    t.service_type          as service_type,
+    t.ratecode_id           as ratecode_id,
+    t.pickup_location_id    as pickup_location_id,
+    pickup.borough          as pickup_borough,
+    pickup.zone             as pickup_zone,
+    t.dropoff_location_id   as dropoff_location_id,
+    dropoff.borough         as dropoff_borough,
+    dropoff.zone            as dropoff_zone,
+    t.pickup_datetime       as pickup_datetime,
+    t.dropoff_datetime      as dropoff_datetime,
+    t.store_and_fwd_flag    as store_and_fwd_flag,
+    t.passenger_count       as passenger_count,
+    t.trip_distance         as trip_distance,
+    t.trip_type             as trip_type,
+    t.fare_amount           as fare_amount,
+    t.extra                 as extra,
+    t.mta_tax               as mta_tax,
+    t.tip_amount            as tip_amount,
+    t.tolls_amount          as tolls_amount,
+    t.ehail_fee             as ehail_fee,
+    t.improvement_surcharge as improvement_surcharge,
+    t.total_amount          as total_amount,
+    t.payment_type          as payment_type,
+    t.congestion_surcharge  as congestion_surcharge
+from 
     all_tripdata t
-INNER JOIN lookup_zones pickup  
-    ON t.pickup_location_id  = pickup.location_id
-INNER JOIN lookup_zones dropoff 
-    ON t.dropoff_location_id = dropoff.location_id
+inner join 
+    lookup_zones pickup on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id

--- a/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
@@ -7,4 +7,5 @@ select
     Borough      as borough,
     Zone         as zone,
     service_zone as service_zone
-from {{ ref('taxi_zone_lookup') }}
+from 
+    {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
@@ -2,10 +2,9 @@
     schema=env_var('DBT_REDSHIFT_SCHEMA')
 ) }}
 
-SELECT
-    LocationID      as location_id,
-    Borough         as borough,
-    Zone            as zone,
-    service_zone    as service_zone
-FROM
-    {{ ref('taxi_zone_lookup') }}
+select
+    LocationID   as location_id,
+    Borough      as borough,
+    Zone         as zone,
+    service_zone as service_zone
+from {{ ref('taxi_zone_lookup') }}

--- a/week_4_analytics_engineering/redshift/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/redshift/models/core/fct_monthly_zone_revenue.sql
@@ -2,24 +2,24 @@
     schema=env_var('DBT_REDSHIFT_SCHEMA')
 ) }}
 
-SELECT
+select
     -- Revenue Grouping
-    pickup_zone                             as revenue_zone,
-    DATE_TRUNC('month', pickup_datetime)    as revenue_month,
-    service_type                            as service_type,
+    pickup_zone                                  as zone,
+    service_type                                 as service_type,
+    {{ date_trunc("month", "pickup_datetime") }} as order_year,
     -- Revenue Calculations
-    ROUND(SUM(fare_amount), 2)              as revenue_monthly_fare,
-    ROUND(SUM(extra), 2)                    as revenue_monthly_extra,
-    ROUND(SUM(mta_tax), 2)                  as revenue_monthly_mta_tax,
-    ROUND(SUM(tip_amount), 2)               as revenue_monthly_tip_amount,
-    ROUND(SUM(tolls_amount), 2)             as revenue_monthly_tolls_amount,
-    ROUND(SUM(ehail_fee), 2)                as revenue_monthly_ehail_fee,
-    ROUND(SUM(improvement_surcharge), 2)    as revenue_monthly_improvement_surcharge,
-    ROUND(SUM(total_amount), 2)             as revenue_monthly_total_amount,
-    ROUND(SUM(congestion_surcharge), 2)     as revenue_monthly_congestion_surcharge
-FROM
+    round(sum(fare_amount), 2)                   as monthly_fare,
+    round(sum(extra), 2)                         as monthly_extra,
+    round(sum(mta_tax), 2)                       as monthly_mta_tax,
+    round(sum(tip_amount), 2)                    as monthly_tip_amount,
+    round(sum(tolls_amount), 2)                  as monthly_tolls_amount,
+    round(sum(ehail_fee), 2)                     as monthly_ehail_fee,
+    round(sum(improvement_surcharge), 2)         as monthly_improvement_surcharge,
+    round(sum(total_amount), 2)                  as monthly_total_amount,
+    round(sum(congestion_surcharge), 2)          as monthly_congestion_surcharge
+from 
     {{ ref('dim_yellow_green_trips') }}
-GROUP BY
-    pickup_zone,
-    DATE_TRUNC('month', pickup_datetime),
-    service_type
+group by 
+    pickup_zone, 
+    service_type,
+    {{ date_trunc("month", "pickup_datetime") }}

--- a/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
@@ -3,22 +3,22 @@
     materialized='table'
 ) }}
 
-SELECT
+select
     -- identifiers
     {{ dbt_utils.generate_surrogate_key([
         'dispatching_base_num',
         'pickup_datetime'
-    ]) }}                   as trip_id,
-    dispatching_base_num    as dispatching_base_num,
-    Affiliated_base_number  as affiliated_base_num,
+    ]) }}                  as trip_id,
+    dispatching_base_num   as dispatching_base_num,
+    Affiliated_base_number as affiliated_base_num,
     -- pickup and dropoff timestamps
-    pickup_datetime         as pickup_datetime,
-    dropOff_datetime        as dropoff_datetime,
+    pickup_datetime        as pickup_datetime,
+    dropOff_datetime       as dropoff_datetime,
     -- trip info
-    PUlocationID            as pickup_location_id,
-    DOlocationID            as dropoff_location_id,
-    SR_Flag                 as shared_ride_flag
-FROM
+    PUlocationID           as pickup_location_id,
+    DOlocationID           as dropoff_location_id,
+    SR_Flag                as shared_ride_flag
+from 
     {{ source('redshift-raw-nyc-trip_record', 'fhv') }}
 
 
@@ -26,5 +26,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
@@ -3,39 +3,39 @@
     materialized='table'
 ) }}
 
-SELECT
+select
     -- identifiers
     {{ dbt_utils.generate_surrogate_key([
         'VendorID',
         'lpep_pickup_datetime'
-    ]) }}                   as trip_id,
-    VendorID                as vendor_id,
-    RatecodeID              as ratecode_id,
-    PULocationID            as pickup_location_id,
-    DOLocationID            as dropoff_location_id,
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    lpep_pickup_datetime    as pickup_datetime,
-    lpep_dropoff_datetime   as dropoff_datetime,
+    lpep_pickup_datetime  as pickup_datetime,
+    lpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    trip_type               as trip_type,
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    trip_type             as trip_type,
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    ehail_fee               as ehail_fee,
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    ehail_fee             as ehail_fee,
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM
+    }}                    as payment_type_desc
+from 
     {{ source('redshift-raw-nyc-trip_record', 'green') }}
 
 
@@ -43,5 +43,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
@@ -37,6 +37,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('redshift-raw-nyc-trip_record', 'green') }}
+where
+    VendorID is not null
 
 
 -- Run as:

--- a/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
@@ -3,39 +3,39 @@
     materialized='table'
 ) }}
 
-SELECT
+select
     -- identifiers
     {{ dbt_utils.generate_surrogate_key([
-        'VendorID',
+        'VendorID', 
         'tpep_pickup_datetime'
-    ]) }}                   as trip_id,
-    VendorID                as vendor_id,
-    RatecodeID              as ratecode_id,
-    PULocationID            as pickup_location_id,
-    DOLocationID            as dropoff_location_id,
+    ]) }}                 as trip_id,
+    VendorID              as vendor_id,
+    RatecodeID            as ratecode_id,
+    PULocationID          as pickup_location_id,
+    DOLocationID          as dropoff_location_id,
     -- pickup and dropoff timestamps
-    tpep_pickup_datetime    as pickup_datetime,
-    tpep_dropoff_datetime   as dropoff_datetime,
+    tpep_pickup_datetime  as pickup_datetime,
+    tpep_dropoff_datetime as dropoff_datetime,
     -- trip info
-    store_and_fwd_flag      as store_and_fwd_flag,
-    passenger_count         as passenger_count,
-    trip_distance           as trip_distance,
-    1                       as trip_type, -- yellow cabs are always street-hail
+    store_and_fwd_flag    as store_and_fwd_flag,
+    passenger_count       as passenger_count,
+    trip_distance         as trip_distance,
+    1                     as trip_type, -- yellow cabs are always street-hail
     -- payment info
-    fare_amount             as fare_amount,
-    extra                   as extra,
-    mta_tax                 as mta_tax,
-    tip_amount              as tip_amount,
-    tolls_amount            as tolls_amount,
-    0                       as ehail_fee, -- it does not apply for yellow cabs
-    improvement_surcharge   as improvement_surcharge,
-    congestion_surcharge    as congestion_surcharge,
-    total_amount            as total_amount,
-    payment_type            as payment_type,
+    fare_amount           as fare_amount,
+    extra                 as extra,
+    mta_tax               as mta_tax,
+    tip_amount            as tip_amount,
+    tolls_amount          as tolls_amount,
+    0                     as ehail_fee, -- it does not apply for yellow cabs
+    improvement_surcharge as improvement_surcharge,
+    congestion_surcharge  as congestion_surcharge,
+    total_amount          as total_amount,
+    payment_type          as payment_type,
     {{ 
         payment_type_desc_for('payment_type')
-    }}                      as payment_type_desc
-FROM
+    }}                    as payment_type_desc
+from 
     {{ source('redshift-raw-nyc-trip_record', 'yellow') }}
 
 
@@ -43,5 +43,5 @@ FROM
 --  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
 --  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
 {% if var('is_test_run', default=false) %}
-    LIMIT 100
+limit 100
 {% endif %}

--- a/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
@@ -37,6 +37,8 @@ select
     }}                    as payment_type_desc
 from 
     {{ source('redshift-raw-nyc-trip_record', 'yellow') }}
+where
+    VendorID is not null
 
 
 -- Run as:


### PR DESCRIPTION
## Summary

* Format `dbt-bigquery` SQL files
* Format `dbt-redshift` SQL files
* Format `dbt-clickhouse` SQL files
* Format `dbt-postgres` SQL files

* Staging models now ignore entries where VendorID is NULL    
    * Generate surrogate key on staging models for ClickHouse fails when VendorID is NULL (yellow_taxi); 
      since we're filtering them out in the dimension layer, extend it to staging table to avoid the issue