### PR TITLE
dbt-bigquery: Add new macro to resolve schema_name

### DIFF
--- a/week_4_analytics_engineering/bigquery/README.md
+++ b/week_4_analytics_engineering/bigquery/README.md
@@ -56,7 +56,8 @@ cat profiles.tmpl.yml >> ~/.dbt/profiles.yml
 
 ```shell
 export DBT_BIGQUERY_PROJECT=iobruno-gcp-labs \
-export DBT_BIGQUERY_DATASET=nyc_trip_record_data \
+export DBT_BIGQUERY_SOURCE_DATASET=raw_nyc_trip_record_data \
+export DBT_BIGQUERY_TARGET_DATASET=nyc_trip_record_data \
 export DBT_BIGQUERY_DATASET_LOCATION=us-central1
 ```
 
@@ -118,7 +119,8 @@ docker build -t dbt_bigquery:latest . --no-cache
 ```shell
 docker run \
   -e DBT_BIGQUERY_PROJECT=iobruno-gcp-labs \
-  -e DBT_BIGQUERY_DATASET=nyc_trip_record_data \
+  -e DBT_BIGQUERY_SOURCE_DATASET=raw_nyc_trip_record_data \
+  -e DBT_BIGQUERY_TARGET_DATASET=nyc_trip_record_data \
   -e DBT_BIGQUERY_DATASET_LOCATION=us-central1 \
   -v /PATH/TO/YOUR/GCP_CREDENTIALS.json:/secrets/gcp_credentials.json \
   --name dbt_bigquery \
@@ -130,6 +132,7 @@ docker run \
 - [x] PEP-517: Packaging and dependency management with PDM
 - [x] Bootstrap dbt with BigQuery Adapter ([dbt-bigquery](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup))
 - [x] Generate and serve docs and Data Lineage Graphs locally
+- [x] Add dbt macro to configure target schemas dinamically
 - [x] Run `dbt-core` in Docker
 - [ ] Complete dbt Labs Learning Path for `dbt-core`
   - [ ] [dbt Fundamentals](https://courses.getdbt.com/courses/fundamentals)

--- a/week_4_analytics_engineering/bigquery/dbt_project.yml
+++ b/week_4_analytics_engineering/bigquery/dbt_project.yml
@@ -28,6 +28,3 @@ models:
       materialized: view
     core:
       materialized: table   
-
-vars:
-  payment_type_values: [1, 2, 3, 4, 5, 6]

--- a/week_4_analytics_engineering/bigquery/macros/resolve_destination_schema.sql
+++ b/week_4_analytics_engineering/bigquery/macros/resolve_destination_schema.sql
@@ -1,0 +1,25 @@
+{% macro resolve_schema_for(model_type) -%}
+
+    {{- resolve_env_prefix() -}} {{- resolve_type(model_type) -}}
+
+{%- endmacro %}
+
+
+{% macro resolve_env_prefix() -%}
+
+    {%- if target.name != 'prod' -%} {{ 'tmp_' }}
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{% macro resolve_type(model_type='staging') -%}
+
+    {%- set target_env_var = 'DBT_BIGQUERY_TARGET_DATASET'  -%}
+    {%- set stging_env_var = 'DBT_BIGQUERY_STAGING_DATASET' -%}
+
+    {%- if model_type == 'core' -%} {{- env_var(target_env_var) -}}
+    {%- else -%}                    {{- env_var(stging_env_var, 'stg_' ~ env_var(target_env_var)) -}}
+    {%- endif -%}
+
+{%- endmacro %}

--- a/week_4_analytics_engineering/bigquery/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_fhv_trips.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('core')
 ) }}
 
 with fhv_tripdata as (

--- a/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_yellow_green_trips.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('core')
 ) }}
 
 with green_tripdata as (

--- a/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/dim_zone_lookup.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('core')
 ) }}
 
 select

--- a/week_4_analytics_engineering/bigquery/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/bigquery/models/core/fct_monthly_zone_revenue.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('core')
 ) }}
 
 select

--- a/week_4_analytics_engineering/bigquery/models/staging/sources.yml
+++ b/week_4_analytics_engineering/bigquery/models/staging/sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: bq-raw-nyc-trip_record
     database: "{{ env_var('DBT_BIGQUERY_PROJECT') }}"
-    schema: "{{ 'raw_' ~ env_var('DBT_BIGQUERY_DATASET') }}"
+    schema:   "{{ env_var('DBT_BIGQUERY_SOURCE_DATASET') }}"
     tables:
       - name: ext_fhv
       - name: ext_green

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_green_tripdata.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_yellow_tripdata.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_BIGQUERY_DATASET')
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/bigquery/profiles.tmpl.yml
+++ b/week_4_analytics_engineering/bigquery/profiles.tmpl.yml
@@ -4,7 +4,7 @@ dbt_bigquery_analytics:
       type: bigquery
       method:   "{{ env_var('DBT_BIGQUERY_AUTH_METHOD', 'oauth') }}"
       project:  "{{ env_var('DBT_BIGQUERY_PROJECT') }}"
-      dataset:  "{{ env_var('DBT_BIGQUERY_DATASET') }}"
+      dataset:  "{{ env_var('DBT_BIGQUERY_TARGET_DATASET') }}"
       location: "{{ env_var('DBT_BIGQUERY_DATASET_LOCATION', 'us-central1') }}"
       priority: interactive
       threads: 4
@@ -15,7 +15,7 @@ dbt_bigquery_analytics:
       type: bigquery
       method:   "{{ env_var('DBT_BIGQUERY_AUTH_METHOD', 'service-account') }}"
       project:  "{{ env_var('DBT_BIGQUERY_PROJECT') }}"
-      dataset:  "{{ env_var('DBT_BIGQUERY_DATASET') }}"
+      dataset:  "{{ env_var('DBT_BIGQUERY_TARGET_DATASET') }}"
       location: "{{ env_var('DBT_BIGQUERY_DATASET_LOCATION', 'us-central1') }}"
       keyfile:  "{{ env_var('GOOGLE_APPLICATION_CREDENTIALS') }}"
       priority: interactive

--- a/week_4_analytics_engineering/bigquery/seeds/properties.yml
+++ b/week_4_analytics_engineering/bigquery/seeds/properties.yml
@@ -8,7 +8,11 @@ seeds:
       # Config options
       #   'schema' overrides default schema (defined in profiles.yml) where it should write the data to
       #   'alias' refers to the table name to be created on the speficied database and sche,a
-      schema: "{{ 'stg_' ~ env_var('DBT_BIGQUERY_DATASET') }}"
+      schema: |-
+        {%- if target.name != "prod" -%} tmp_ 
+        {%- endif -%}
+        {{ env_var('DBT_BIGQUERY_STAGING_DATASET', 'stg_' ~ env_var('DBT_BIGQUERY_TARGET_DATASET')) }}
+
       alias:  "{{ 'stg_' ~ 'zone_lookup' }}"
 
       # Refer to https://docs.getdbt.com/reference/seed-configs 


### PR DESCRIPTION
## Summary

* Add macro to set the configuration.schema for the models based on target.name and model_type

* Adds the optional env_var 'DBT_BIGQUERY_STAGING_DATASET', 
   which when not set will default to 'stg_' ~ 'DBT_BIGQUERY_TARGET_DATASET'

* env_var 'DBT_BIGQUERY_DATASET' is now 'DBT_BIGQUERY_TARGET_DATASET'

* Update Dockerfile and README accordingly