### PR TITLE
dbt-redshift: Add new macro to resolve schema_name

### DIFF
--- a/week_4_analytics_engineering/redshift/README.md
+++ b/week_4_analytics_engineering/redshift/README.md
@@ -61,9 +61,16 @@ cat profiles.tmpl.yml >> ~/.dbt/profiles.yml
 ```shell
 export DBT_REDSHIFT_HOST=hostname.region.redshift-serverless.amazonaws.com \
 export DBT_REDSHIFT_DATABASE=dev \
-export DBT_REDSHIFT_SCHEMA=nyc_trip_record_data \
+export DBT_REDSHIFT_USE_DATA_CATALOG=1 \
+export DBT_REDSHIFT_SOURCE_GLUE_CATALOG_DB=raw_nyc_trip_record_data \
+export DBT_REDSHIFT_TARGET_SCHEMA=nyc_trip_record_data
 ```
 
+Also, either have your AWS credentials set on `~/.aws/credentials` or set them as well:
+```shell
+export AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID \
+export AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
+```
 
 **5.** Install dbt dependencies and trigger the pipeline
 
@@ -117,11 +124,13 @@ docker build -t dbt_redshift:latest . --no-cache
 **2.** Start a container with it:
 ```shell
 docker run \
-  -e DBT_REDSHIFT_HOST=hostname.region.redshift-serverless.amazonaws.com \
+  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  -e DBT_REDSHIFT_HOST=$DBT_REDSHIFT_HOST \
   -e DBT_REDSHIFT_DATABASE=dev \
-  -e DBT_REDSHIFT_SCHEMA=nyc_trip_record_data \
-  -e AWS_ACCESS_KEY_ID=myAwsAccessKeyId \
-  -e AWS_SECRET_ACCESS_KEY=myAwsSecretAccessKey \
+  -e DBT_REDSHIFT_USE_DATA_CATALOG=1 \
+  -e DBT_REDSHIFT_SOURCE_GLUE_CATALOG_DB=raw_nyc_trip_record_data \
+  -e DBT_REDSHIFT_TARGET_SCHEMA=nyc_trip_record_data \
   --name dbt_redshift \
   dbt_redshift
 ```
@@ -130,5 +139,6 @@ docker run \
 ## TODO:
 - [x] PEP-517: Packaging and dependency management with PDM
 - [x] Bootstrap dbt with Redshift Adapter ([dbt-redshift](https://docs.getdbt.com/docs/core/connect-data-platform/redshift-setup))
+- [x] Add dbt macro to configure target schemas dinamically
 - [x] Run `dbt-core` in Docker
 - [ ] Terraform AWS Glue Catalog and Crawler

--- a/week_4_analytics_engineering/redshift/dbt_project.yml
+++ b/week_4_analytics_engineering/redshift/dbt_project.yml
@@ -25,6 +25,6 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   dbt_redshift_analytics:
     staging:
-      materialized: view
+      materialized: table
     core:
       materialized: table

--- a/week_4_analytics_engineering/redshift/macros/resolve_destination_schema.sql
+++ b/week_4_analytics_engineering/redshift/macros/resolve_destination_schema.sql
@@ -1,0 +1,25 @@
+{% macro resolve_schema_for(model_type) -%}
+
+    {{- resolve_env_prefix() -}} {{- resolve_type(model_type) -}}
+
+{%- endmacro %}
+
+
+{% macro resolve_env_prefix() -%}
+
+    {%- if target.name != 'prod' -%} {{ 'tmp_' }}
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{% macro resolve_type(model_type='staging') -%}
+
+    {%- set target_env_var = 'DBT_REDSHIFT_TARGET_SCHEMA'  -%}
+    {%- set stging_env_var = 'DBT_REDSHIFT_STAGING_SCHEMA' -%}
+
+    {%- if model_type == 'core' -%} {{- env_var(target_env_var) -}}
+    {%- else -%}                    {{- env_var(stging_env_var, 'stg_' ~ env_var(target_env_var)) -}}
+    {%- endif -%}
+
+{%- endmacro %}

--- a/week_4_analytics_engineering/redshift/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_fhv_trips.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_REDSHIFT_SCHEMA')
+    schema=resolve_schema_for('core')
 ) }}
 
 with fhv_tripdata as (

--- a/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_yellow_green_trips.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_REDSHIFT_SCHEMA')
+    schema=resolve_schema_for('core')
 ) }}
 
 with green_tripdata as (

--- a/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/redshift/models/core/dim_zone_lookup.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_REDSHIFT_SCHEMA')
+    schema=resolve_schema_for('core')
 ) }}
 
 select

--- a/week_4_analytics_engineering/redshift/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/redshift/models/core/fct_monthly_zone_revenue.sql
@@ -1,5 +1,5 @@
 {{ config(
-    schema=env_var('DBT_REDSHIFT_SCHEMA')
+    schema=resolve_schema_for('core')
 ) }}
 
 select

--- a/week_4_analytics_engineering/redshift/models/staging/sources.yml
+++ b/week_4_analytics_engineering/redshift/models/staging/sources.yml
@@ -2,8 +2,12 @@ version: 2
 
 sources:
   - name: redshift-raw-nyc-trip_record
-    database: "awsdatacatalog"
-    schema:   "nyc_trip_record_data"
+    database: |-
+      {%- if env_var('DBT_REDSHIFT_USE_DATA_CATALOG', 0) == '1' -%} awsdatacatalog
+      {%- else -%} {{ env_var('DBT_REDSHIFT_DATABASE') }}
+      {%- endif -%}
+
+    schema: "{{ env_var('DBT_REDSHIFT_SOURCE_SCHEMA', env_var('DBT_REDSHIFT_SOURCE_GLUE_CATALOG_DB')) }}"
     tables:
       - name: fhv
       - name: green

--- a/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_REDSHIFT_SCHEMA'),
-    materialized='table'
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_green_tripdata.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_REDSHIFT_SCHEMA'),
-    materialized='table'
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_yellow_tripdata.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema='stg_' ~ env_var('DBT_REDSHIFT_SCHEMA'),
-    materialized='table'
+    schema=resolve_schema_for('staging')
 ) }}
 
 select

--- a/week_4_analytics_engineering/redshift/profiles.tmpl.yml
+++ b/week_4_analytics_engineering/redshift/profiles.tmpl.yml
@@ -3,22 +3,22 @@ dbt_redshift_analytics:
     dev:
       type: redshift
       method: iam
-      host:   "{{ env_var('DBT_REDSHIFT_HOST') }}"
-      port:   "{{ env_var('DBT_REDSHIFT_PORT', 5439) | as_number }}"
-      dbname: "{{ env_var('DBT_REDSHIFT_DATABASE') }}"
-      schema: "{{ env_var('DBT_REDSHIFT_SCHEMA') }}"
-      user:   "{{ env_var('DBT_REDSHIFT_USER', 'admin') }}"
+      host:     "{{ env_var('DBT_REDSHIFT_HOST') }}"
+      port:     "{{ env_var('DBT_REDSHIFT_PORT', 5439) | as_number }}"
+      dbname:   "{{ env_var('DBT_REDSHIFT_DATABASE') }}"
+      schema:   "{{ env_var('DBT_REDSHIFT_TARGET_SCHEMA') }}"
+      user:     "{{ env_var('DBT_REDSHIFT_USER', 'admin') }}"
       password: "{{ env_var('DBT_REDSHIFT_PASSWORD') }}"
       threads: 4
 
     prod:
       type: redshift
       method: iam
-      host:   "{{ env_var('DBT_REDSHIFT_HOST') }}"
-      port:   "{{ env_var('DBT_REDSHIFT_PORT', 5439) | as_number }}"
-      dbname: "{{ env_var('DBT_REDSHIFT_DATABASE') }}"
-      schema: "{{ env_var('DBT_REDSHIFT_SCHEMA') }}"
-      user:   "{{ env_var('DBT_REDSHIFT_USER', 'admin') }}"
+      host:     "{{ env_var('DBT_REDSHIFT_HOST') }}"
+      port:     "{{ env_var('DBT_REDSHIFT_PORT', 5439) | as_number }}"
+      dbname:   "{{ env_var('DBT_REDSHIFT_DATABASE') }}"
+      schema:   "{{ env_var('DBT_REDSHIFT_TARGET_SCHEMA') }}"
+      user:     "{{ env_var('DBT_REDSHIFT_USER', 'admin') }}"
       password: "{{ env_var('DBT_REDSHIFT_PASSWORD') }}"
       threads: 1
 

--- a/week_4_analytics_engineering/redshift/seeds/properties.yml
+++ b/week_4_analytics_engineering/redshift/seeds/properties.yml
@@ -8,7 +8,11 @@ seeds:
       # Config options
       #   'schema' overrides default schema (defined in profiles.yml) where it should write the data to
       #   'alias' refers to the table name to be created on the speficied database and sche,a
-      schema: "{{ 'stg_' ~ env_var('DBT_REDSHIFT_SCHEMA') }}"
+      schema: |-
+        {%- if target.name != "prod" -%} tmp_ 
+        {%- endif -%}
+        {{ env_var('DBT_REDSHIFT_STAGING_SCHEMA', 'stg_' ~ env_var('DBT_REDSHIFT_TARGET_SCHEMA')) }}
+
       alias:  "{{ 'stg_' ~ 'zone_lookup' }}"
 
       # Refer to https://docs.getdbt.com/reference/seed-configs 


### PR DESCRIPTION
## Summary

* Add macro to set the configuration.schema for the models based on target.name and model_type

* Adds the optional env_var 'DBT_REDSHIFT_STAGING_SCHEMA', 
   which when not set will default to 'stg_' ~ 'DBT_REDSHIFT_TARGET_SCHEMA'

* Adds the optional env_var 'DBT_REDSHIFT_USE_DATA_CATALOG',
   which when not set will default t0 '0'

* When `DBT_REDSHIFT_USE_DATA_CATALOG` is set to 1, the `DBT_REDSHIFT_STAGING_SCHEMA` env_var
   will, instead, default to 'awsdatacatalog', and the source_schema can set either on 
   `DBT_REDSHIFT_SOURCE_SCHEMA` or `DBT_REDSHIFT_SOURCE_GLUE_CATALOG_DB`

* env_var 'DBT_REDSHIFT_SCHEMA' is now 'DBT_REDSHIFT_TARGET_SCHEMA'

* Update Dockerfile and README accordingly