### PR TITLE
Add fhv-dbt-model for CH/Postgres and Fix for BigQuery/RedShift

### DIFF
--- a/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/bigquery/models/staging/stg_fhv_tripdata.sql
@@ -19,6 +19,8 @@ select
     SR_Flag                as shared_ride_flag
 from 
     {{ source('bq-raw-nyc-trip_record', 'ext_fhv') }}
+where
+    dispatching_base_num is not null
 
 
 -- Run as:

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_fhv_trips.sql
@@ -1,0 +1,44 @@
+{{ config(
+    schema=resolve_schema_for('core')
+) }}
+
+with fhv_tripdata as (
+    select
+        dispatching_base_num,
+        affiliated_base_num,
+        pickup_datetime,
+        dropoff_datetime,
+        pickup_location_id,
+        dropoff_location_id,
+        shared_ride_flag,
+        row_number() over (partition by dispatching_base_num, pickup_datetime) as row_num
+    from 
+        {{ ref('stg_fhv_tripdata') }}
+),
+
+lookup_zones as (
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
+)
+
+select
+    t.dispatching_base_num as dispatching_base_num,
+    t.affiliated_base_num  as affiliated_base_num,
+    t.pickup_location_id   as pickup_location_id,
+    pickup.borough         as pickup_borough,
+    pickup.zone            as pickup_zone,
+    pickup.service_zone    as pickup_service_zone,
+    t.dropoff_location_id  as dropoff_location_id,
+    dropoff.borough        as dropoff_borough,
+    dropoff.zone           as dropoff_zone,
+    dropoff.service_zone   as dropoff_service_zone,
+    t.shared_ride_flag     as shared_ride_flag,
+    t.pickup_datetime      as pickup_datetime,
+    t.dropoff_datetime     as dropoff_datetime
+from  
+    fhv_tripdata t
+inner join 
+    lookup_zones pickup  on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id
+where 
+    t.row_num = 1

--- a/week_4_analytics_engineering/clickhouse/models/staging/sources.yml
+++ b/week_4_analytics_engineering/clickhouse/models/staging/sources.yml
@@ -6,3 +6,4 @@ sources:
     tables:
       - name: ntl_yellow_taxi
       - name: ntl_green_taxi
+      - name: ntl_fhv_taxi

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
@@ -1,0 +1,31 @@
+{{ config(
+    schema=resolve_schema_for('staging')
+) }}
+
+select
+    -- identifiers
+    {{ dbt_utils.generate_surrogate_key([
+        'dispatching_base_num',
+        'pickup_datetime'
+    ]) }}                        as trip_id,
+    dispatching_base_num         as dispatching_base_num,
+    affiliated_base_number       as affiliated_base_num,
+    -- pickup and dropoff timestamps
+    toDateTime(pickup_datetime)  as pickup_datetime,
+    toDateTime(dropoff_datetime) as dropoff_datetime,
+    -- trip info
+    toInt16(pulocationid)        as pickup_location_id,
+    toInt16(dolocationid)        as dropoff_location_id,
+    sr_flag                      as shared_ride_flag
+from 
+    {{ source('clickhouse-federated-postgres-nyc-trip_record', 'ntl_fhv_taxi') }}
+where
+    dispatching_base_num is not null
+
+
+-- Run as:
+--  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
+--  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
+{% if var('is_test_run', default=false) %}
+limit 100
+{% endif %}

--- a/week_4_analytics_engineering/postgres/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/postgres/models/core/dim_fhv_trips.sql
@@ -1,0 +1,44 @@
+{{ config(
+    schema=resolve_schema_for('core')
+) }}
+
+with fhv_tripdata as (
+    select
+        dispatching_base_num,
+        affiliated_base_num,
+        pickup_datetime,
+        dropoff_datetime,
+        pickup_location_id,
+        dropoff_location_id,
+        shared_ride_flag,
+        row_number() over (partition by dispatching_base_num, pickup_datetime) as row_num
+    from 
+        {{ ref('stg_fhv_tripdata') }}
+),
+
+lookup_zones as (
+    select * from {{ ref('dim_zone_lookup' )}} where borough != 'Unknown'
+)
+
+select
+    t.dispatching_base_num as dispatching_base_num,
+    t.affiliated_base_num  as affiliated_base_num,
+    t.pickup_location_id   as pickup_location_id,
+    pickup.borough         as pickup_borough,
+    pickup.zone            as pickup_zone,
+    pickup.service_zone    as pickup_service_zone,
+    t.dropoff_location_id  as dropoff_location_id,
+    dropoff.borough        as dropoff_borough,
+    dropoff.zone           as dropoff_zone,
+    dropoff.service_zone   as dropoff_service_zone,
+    t.shared_ride_flag     as shared_ride_flag,
+    t.pickup_datetime      as pickup_datetime,
+    t.dropoff_datetime     as dropoff_datetime
+from  
+    fhv_tripdata t
+inner join 
+    lookup_zones pickup  on t.pickup_location_id  = pickup.location_id
+inner join 
+    lookup_zones dropoff on t.dropoff_location_id = dropoff.location_id
+where 
+    t.row_num = 1

--- a/week_4_analytics_engineering/postgres/models/staging/sources.yml
+++ b/week_4_analytics_engineering/postgres/models/staging/sources.yml
@@ -1,9 +1,10 @@
 version: 2
 
 sources:
-  - name: pg-raw-nyc-trip_record
+  - name: postgres-raw-nyc-trip_record
     database: "{{ env_var('DBT_POSTGRES_DATABASE') }}"
     schema:   "{{ env_var('DBT_POSTGRES_SOURCE_SCHEMA') }}"
     tables:
       - name: ntl_green_taxi
       - name: ntl_yellow_taxi
+      - name: ntl_fhv_taxi

--- a/week_4_analytics_engineering/postgres/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_fhv_tripdata.sql
@@ -1,0 +1,30 @@
+{{ config(
+    schema=resolve_schema_for('staging')
+) }}
+
+select
+    -- identifiers
+    {{ dbt_utils.generate_surrogate_key([
+        'dispatching_base_num',
+        'pickup_datetime'
+    ]) }}                  as trip_id,
+    dispatching_base_num   as dispatching_base_num,
+    Affiliated_base_number as affiliated_base_num,
+    -- pickup and dropoff timestamps
+    pickup_datetime        as pickup_datetime,
+    dropOff_datetime       as dropoff_datetime,
+    -- trip info
+    PUlocationID           as pickup_location_id,
+    DOlocationID           as dropoff_location_id,
+    SR_Flag                as shared_ride_flag
+from 
+    {{ source('postgres-raw-nyc-trip_record', 'ntl_fhv_taxi') }}
+where
+    dispatching_base_num is not null
+
+-- Run as:
+--  dbt build --select stg_green_tripdata --vars 'is_test_run: true'
+--  dbt run --select stg_green_tripdata --vars 'is_test_run: false'
+{% if var('is_test_run', default=false) %}
+limit 100
+{% endif %}

--- a/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_green_tripdata.sql
@@ -33,7 +33,7 @@ select
     payment_type                          as payment_type,
     {{ payment_desc_of('payment_type') }} as payment_type_desc
 from 
-    {{ source('pg-raw-nyc-trip_record', 'ntl_green_taxi') }}
+    {{ source('postgres-raw-nyc-trip_record', 'ntl_green_taxi') }}
 where
     vendorid is not null
 

--- a/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/postgres/models/staging/stg_yellow_tripdata.sql
@@ -33,7 +33,7 @@ select
     payment_type                          as payment_type,
     {{ payment_desc_of('payment_type') }} as payment_type_desc
 from 
-    {{ source('pg-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
+    {{ source('postgres-raw-nyc-trip_record', 'ntl_yellow_taxi') }}
 where
     vendorid is not null
 

--- a/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/redshift/models/staging/stg_fhv_tripdata.sql
@@ -19,6 +19,8 @@ select
     SR_Flag                as shared_ride_flag
 from 
     {{ source('redshift-raw-nyc-trip_record', 'fhv') }}
+where
+    dispatching_base_num is not null
 
 
 -- Run as:


### PR DESCRIPTION
## Summary
    
* Add `stg_fhv_tripdata` and `dim_fhv_trips` for PostgreSQL and ClickHouse

* Fix `stg_fhv_tripdata` for BigQuery and RedShift filtering out invalid entries
  (dispatching_base_num is not null) 
