### PR TITLE
feat/dbt-clickhouse: Query optimization

### DIFF
--- a/week_4_analytics_engineering/clickhouse/models/core/dim_fhv_trips.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_fhv_trips.sql
@@ -1,5 +1,8 @@
 {{ config(
-    schema=resolve_schema_for('core')
+    schema=resolve_schema_for('core'),
+    order_by='(dispatching_base_num, pickup_datetime, pickup_location_id, dropoff_location_id)',
+    engine='MergeTree()',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 with fhv_tripdata as (

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_yellow_green_trips.sql
@@ -1,5 +1,8 @@
 {{ config(
-    schema=resolve_schema_for('core')
+    schema=resolve_schema_for('core'),
+    order_by='(pickup_location_id, dropoff_location_id, vendor_id)',
+    engine='MergeTree()',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 with green_tripdata as (

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema=resolve_schema_for('core'),
     order_by='(location_id, borough)',
-    engine='MergeTree()'
+    engine='MergeTree()',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/dim_zone_lookup.sql
@@ -1,5 +1,7 @@
 {{ config(
-    schema=resolve_schema_for('core')
+    schema=resolve_schema_for('core'),
+    order_by='(location_id, borough)',
+    engine='MergeTree()'
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema=resolve_schema_for('core'),
     orderby='(pickup_zone, order_year, service_type)',
-    engine='MergeTree()'
+    engine='MergeTree()',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
+++ b/week_4_analytics_engineering/clickhouse/models/core/fct_monthly_zone_revenue.sql
@@ -1,5 +1,7 @@
 {{ config(
-    schema=resolve_schema_for('core')
+    schema=resolve_schema_for('core'),
+    orderby='(pickup_zone, order_year, service_type)',
+    engine='MergeTree()'
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
@@ -2,7 +2,6 @@
     schema=resolve_schema_for('staging'),
     order_by='(pickup_location_id, dropoff_location_id)',
     engine='MergeTree()',
-    unique_key='trip_id',
     settings={'allow_nullable_key': 1}
 ) }}
 

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_fhv_tripdata.sql
@@ -1,5 +1,9 @@
 {{ config(
-    schema=resolve_schema_for('staging')
+    schema=resolve_schema_for('staging'),
+    order_by='(pickup_location_id, dropoff_location_id)',
+    engine='MergeTree()',
+    unique_key='trip_id',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
@@ -2,7 +2,6 @@
     schema=resolve_schema_for('staging'),
     order_by='(vendor_id, pickup_datetime, pickup_location_id, dropoff_location_id)',
     engine='MergeTree()',
-    unique_key='trip_id',
     settings={'allow_nullable_key': 1}
 ) }}
 

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_green_tripdata.sql
@@ -1,5 +1,9 @@
 {{ config(
-    schema=resolve_schema_for('staging')
+    schema=resolve_schema_for('staging'),
+    order_by='(vendor_id, pickup_datetime, pickup_location_id, dropoff_location_id)',
+    engine='MergeTree()',
+    unique_key='trip_id',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 select

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
@@ -2,7 +2,6 @@
     schema=resolve_schema_for('staging'),
     order_by='(vendor_id, pickup_datetime, pickup_location_id, dropoff_location_id)',
     engine='MergeTree()',
-    unique_key='trip_id',
     settings={'allow_nullable_key': 1}
 ) }}
 

--- a/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
+++ b/week_4_analytics_engineering/clickhouse/models/staging/stg_yellow_tripdata.sql
@@ -1,5 +1,9 @@
 {{ config(
-    schema=resolve_schema_for('staging')
+    schema=resolve_schema_for('staging'),
+    order_by='(vendor_id, pickup_datetime, pickup_location_id, dropoff_location_id)',
+    engine='MergeTree()',
+    unique_key='trip_id',
+    settings={'allow_nullable_key': 1}
 ) }}
 
 select


### PR DESCRIPTION
## Summary
    
* Optimize `staging` and `core` dbt models based on fields used on `partition_by` or `where` clauses 

* Enforces settings for `{'allow_nullable_key': 1}`

* Explicitly set the table engines to be `MergeTree( )`

* This also prevents ClickHouse from running out of Memory