### PR TITLE
fix: orchestrators docker-compose

### DIFF
--- a/module2-workflow-orchestration/airflow-legacy/README.md
+++ b/module2-workflow-orchestration/airflow-legacy/README.md
@@ -31,7 +31,7 @@ docker compose up -d
 **2.** Airflow WebUI can be accessed at:
 
 ```shell
-open http://localhost:8080
+open http://localhost:8081
 ```
 
 **3.** Airflow DAGs

--- a/module2-workflow-orchestration/airflow-legacy/README.md
+++ b/module2-workflow-orchestration/airflow-legacy/README.md
@@ -2,13 +2,12 @@
 
 ![Python](https://img.shields.io/badge/Python-3.8_|_3.9-4B8BBE.svg?style=flat&logo=python&logoColor=FFD43B&labelColor=306998)
 ![Airflow](https://img.shields.io/badge/Airflow-1.10.15-00C9D6?style=flat&logo=apacheairflow&logoColor=white&labelColor=007A87)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Docker](https://img.shields.io/badge/Docker-329DEE?style=flat&logo=docker&logoColor=white&labelColor=329DEE)
 
 ![License](https://img.shields.io/badge/license-CC--BY--SA--4.0-31393F?style=flat&logo=creativecommons&logoColor=black&labelColor=white)
 
 
-Do NOT use this for new projects. Instead refer to [Airflow 2.x](../airflow/)
+Do **NOT** use this for new projects. Instead refer to [Airflow 2.x](../airflow/)
 
 Infrastructure setup for Airflow 1.x in Docker, optimized for native execution on Apple Silicon (arm64). Designed specifically for handling legacy Airflow environments, such as migrations from Airflow 1.x DAGs to Airflow 2.x.
 

--- a/module2-workflow-orchestration/airflow-legacy/docker-compose.yml
+++ b/module2-workflow-orchestration/airflow-legacy/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow_legacy
     ports:
-      - '5432:5432'
+      - '5432'
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
@@ -54,7 +54,7 @@ services:
     image: *redis-image
     container_name: airflow_legacy_redis
     ports:
-      - '6379:6379'
+      - '6379'
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 5s
@@ -67,7 +67,7 @@ services:
     container_name: airflow_legacy_web
     command: ["webserver"]
     ports:
-      - '8080:8080'
+      - '8081:8080'
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:

--- a/module2-workflow-orchestration/airflow-legacy/docker-compose.yml
+++ b/module2-workflow-orchestration/airflow-legacy/docker-compose.yml
@@ -15,24 +15,24 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_FOLDER: /opt/airflow/dags
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/plugins
     AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/logs
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow_legacy
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-db/airflow_legacy
     AIRFLOW__WEBSERVER__AUTHENTICATE: 'false'
     AIRFLOW__WEBSERVER__AUTH_BACKEND: airflow.contrib.auth.backends.password_auth
-    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
-    AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-db/airflow
+    AIRFLOW__CELERY__BROKER_URL: redis://:@airflow-redis:6379/
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
   depends_on:
     &airflow-common-depends-on
-    postgres:
+    airflow-db:
       condition: service_healthy
-    redis:
+    airflow-redis:
       condition: service_healthy
 
 services:
-  postgres:
+  airflow-db:
     image: *postgres-image
     container_name: airflow_legacy_postgres
     environment:
@@ -50,7 +50,7 @@ services:
       retries: 5
     restart: on-failure
 
-  redis:
+  airflow-redis:
     image: *redis-image
     container_name: airflow_legacy_redis
     ports:

--- a/module2-workflow-orchestration/airflow/README.md
+++ b/module2-workflow-orchestration/airflow/README.md
@@ -2,18 +2,15 @@
 
 ![Python](https://img.shields.io/badge/Python-3.10_|_3.11-4B8BBE.svg?style=flat&logo=python&logoColor=FFD43B&labelColor=306998)
 ![Airflow](https://img.shields.io/badge/Airflow-2.7-3772FF?style=flat&logo=apacheairflow&logoColor=white&labelColor=3772FF)
-![Pandas](https://img.shields.io/badge/pandas-150458?style=flat&logo=pandas&logoColor=E70488&labelColor=150458)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Docker](https://img.shields.io/badge/Docker-329DEE?style=flat&logo=docker&logoColor=white&labelColor=329DEE)
 
 ![License](https://img.shields.io/badge/license-CC--BY--SA--4.0-31393F?style=flat&logo=creativecommons&logoColor=black&labelColor=white)
 
-This setups the infrastructure for Airflow, in Docker, as close as possible to a deploy in a Kubernetes/Helm environment: having containers for the `airflow-scheduler`, `airflow-web`, `airflow-triggerer`, and `airflow-worker` (the CeleryExecutor)
+This setups the infrastructure for Airflow, in Docker, as close as possible to a deploy in a Kubernetes/Helm environment: having containers for the `airflow-scheduler`, `airflow-web`, `airflow-triggerer`, and `airflow-worker` (with the CeleryExecutor)
 
 
 ## Tech Stack
 - [Airflow](https://airflow.apache.org/docs/apache-airflow/stable/start.html)
-- [pandas](https://pandas.pydata.org/docs/user_guide/)
 - [PDM](https://pdm-project.org/latest/usage/dependency/)
 - [Ruff](https://docs.astral.sh/ruff/configuration/)
 - [Docker](https://docs.docker.com/get-docker/)
@@ -25,14 +22,14 @@ This setups the infrastructure for Airflow, in Docker, as close as possible to a
 
 **1.** Start setting up the infrastructure in Docker with:
 
+**Airflow with LocalExecutor**:
+```shell
+docker compose up -d
+```
+
 **Airflow with CeleryExecutor**:
 ```shell
 docker compose -f docker-compose.celery.yml up -d
-```
-
-**Airflow with LocalExecutor**:
-```shell
-docker compose -f docker-compose.local.yml up -d
 ```
 
 
@@ -42,15 +39,15 @@ docker compose -f docker-compose.local.yml up -d
 open http://localhost:8080
 ```
 
-**3.** Airflow DAGs
+**3.** Airflow DAGs:
 
 To deploy Airflow DAGs, just move them inside the [dags](dags/) folder and Airflow should pick it up soon enough
 
 
 ## TODO:
-- [ ] PEP-517: Packaging and dependency management with PDM
+- [x] PEP-517: Packaging and dependency management with PDM
+- [ ] Run Airflow DAGs on Docker
 - [ ] Code format/lint with Ruff
-- [ ]  Run Airflow DAGs on Docker
 - [ ] Complete [Astronomer Academy's Airflow 101](https://academy.astronomer.io/path/airflow-101)
 - [ ] Deploy [Airflow to Kubernetes with Helm](https://airflow.apache.org/docs/helm-chart/stable/index.html)
 - [ ] Run/Deploy [Airflow DAGs on Kubernetes with KubernetesPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/operators.html)

--- a/module2-workflow-orchestration/airflow/docker-compose.celery.yml
+++ b/module2-workflow-orchestration/airflow/docker-compose.celery.yml
@@ -15,10 +15,10 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
-    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-db/airflow
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
-    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
-    AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-db/airflow
+    AIRFLOW__CELERY__BROKER_URL: redis://:@airflow-redis:6379/0
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
@@ -26,13 +26,13 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
   depends_on:
-    redis:
+    airflow-db:
       condition: service_healthy
-    postgres:
+    airflow-redis:
       condition: service_healthy
 
 services:
-  postgres:
+  airflow-db:
     image: *postgres-image
     container_name: airflow_postgres
     restart: always
@@ -50,7 +50,7 @@ services:
       timeout: 3s
       retries: 5
 
-  redis:
+  airflow-redis:
     image: *redis-image
     container_name: airflow_redis
     restart: always

--- a/module2-workflow-orchestration/airflow/docker-compose.celery.yml
+++ b/module2-workflow-orchestration/airflow/docker-compose.celery.yml
@@ -41,7 +41,7 @@ services:
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow
     ports:
-      - '5432:5432'
+      - '5432'
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
@@ -55,7 +55,7 @@ services:
     container_name: airflow_redis
     restart: always
     ports:
-      - '6379:6379'
+      - '6379'
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 5s
@@ -81,7 +81,7 @@ services:
     restart: always
     command: ["airflow", "scheduler"]
     ports:
-      - '8974:8974'
+      - '8974'
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:8974/health"]
       interval: 5s

--- a/module2-workflow-orchestration/airflow/docker-compose.yml
+++ b/module2-workflow-orchestration/airflow/docker-compose.yml
@@ -14,7 +14,7 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
-    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@airflow-db/airflow
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
@@ -23,11 +23,11 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
   depends_on:
-    postgres:
+    airflow-db:
       condition: service_healthy
 
 services:
-  postgres:
+  airflow-db:
     image: *postgres-image
     container_name: airflow_postgres
     restart: always

--- a/module2-workflow-orchestration/airflow/docker-compose.yml
+++ b/module2-workflow-orchestration/airflow/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     restart: always
     command: ["airflow", "webserver"]
     ports:
-      - '8080'
+      - '8080:8080'
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:8080/health"]
       interval: 5s

--- a/module2-workflow-orchestration/airflow/docker-compose.yml
+++ b/module2-workflow-orchestration/airflow/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow
     ports:
-      - '5432:5432'
+      - '5432'
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
@@ -51,7 +51,7 @@ services:
     restart: always
     command: ["airflow", "webserver"]
     ports:
-      - '8080:8080'
+      - '8080'
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:8080/health"]
       interval: 5s
@@ -64,7 +64,7 @@ services:
     restart: always
     command: ["airflow", "scheduler"]
     ports:
-      - '8974:8974'
+      - '8974'
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:8974/health"]
       interval: 5s

--- a/module2-workflow-orchestration/mage/README.md
+++ b/module2-workflow-orchestration/mage/README.md
@@ -2,8 +2,6 @@
 
 ![Python](https://img.shields.io/badge/Python-3.10_|_3.11-4B8BBE.svg?style=flat&logo=python&logoColor=FFD43B&labelColor=306998)
 ![Mage.ai](https://img.shields.io/badge/Mage.ai-0.9-111113?style=flat&logoColor=white&labelColor=111113)
-![Pandas](https://img.shields.io/badge/pandas-150458?style=flat&logo=pandas&logoColor=E70488&labelColor=150458)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Docker](https://img.shields.io/badge/Docker-329DEE?style=flat&logo=docker&logoColor=white&labelColor=329DEE)
 
 ![License](https://img.shields.io/badge/license-CC--BY--SA--4.0-31393F?style=flat&logo=creativecommons&logoColor=black&labelColor=white)

--- a/module2-workflow-orchestration/mage/docker-compose.yml
+++ b/module2-workflow-orchestration/mage/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       POSTGRES_PASSWORD: mage
       POSTGRES_DB: mage
     ports:
-      - '5432:5432'
+      - '5432'
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
@@ -49,7 +49,7 @@ services:
     container_name: mage_redis
     restart: always
     ports:
-      - '6379:6379'
+      - '6379'
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 5s

--- a/module2-workflow-orchestration/mage/docker-compose.yml
+++ b/module2-workflow-orchestration/mage/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       INSTANCE_TYPE: 'web_server'
     ports:
       - '6789:6789'
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:6789/"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   mage-scheduler:
     <<: *mage-common

--- a/module2-workflow-orchestration/mage/docker-compose.yml
+++ b/module2-workflow-orchestration/mage/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 
-x-mage-image: &mage-image mageai/mageai:${MAGE_VERSION:-0.9.58}
+x-mage-image: &mage-image mageai/mageai:${MAGE_VERSION:-0.9.62}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
 x-redis-image: &redis-image redis:${REDIS_VERSION:-7.2}
 
@@ -9,24 +9,24 @@ x-mage-common:
   image: *mage-image
   environment:
     &mage-common-env
-    REDIS_URL: 'redis://@redis:6379/0'
-    MAGE_DATABASE_CONNECTION_URL: 'postgresql+psycopg2://mage:mage@postgres/mage'
+    MAGE_DATABASE_CONNECTION_URL: 'postgresql+psycopg2://mage:mage@mage-db/mage'
+    REDIS_URL: 'redis://@mage-redis:6379/0'
     USER_CODE_PATH: ${MAGE_BASE_DIR:-/opt/mage}
     MAGE_BASE_DIR:  ${MAGE_BASE_DIR:-/opt/mage}
     MAGE_PROJ_NAME: ${MAGE_PROJ_NAME:-magic}
   volumes:
     - ${MAGE_PROJ_DIR:-.}:${MAGE_BASE_DIR:-/opt/mage}
   depends_on:
-    redis:
+    mage-db:
       condition: service_healthy
-    postgres:
+    mage-redis:
       condition: service_healthy
     mage-init:
       condition: service_completed_successfully
   restart: on-failure
 
 services:
-  postgres:
+  mage-db:
     image: *postgres-image
     container_name: mage_postgres
     restart: always
@@ -44,7 +44,7 @@ services:
       timeout: 3s
       retries: 5
 
-  redis:
+  mage-redis:
     image: *redis-image
     container_name: mage_redis
     restart: always


### PR DESCRIPTION
## Summary

* Update airflow 2.x docker-compose
  * Renames 'postgres' to 'airflow-db', and 'redis' to 'airflow-redis' on docker-compose files
  * Renames `docker-compose.local.yml` to the standard `docker-compose.yml`
  * Update README accordingly

* Update mage docker-compose
  * Bump mage docker image to 0.9.62
  * Renames 'postgres' to 'mage-db', and 'redis' to 'mage-redis' on docker-compose

* Update airflow-legacy (1.x) docker-compose
  * Renames 'postgres' to 'airflow-db', and 'redis' to 'airflow-redis' on docker-compose
  * Update port binding to '8081:8080' from '8080:8080' 
  * Update README accordingly
