### PR TITLE
fix: table names for green, yellow, fhv trips

### DIFF
--- a/module1-data-ingestion/python-ingest/src/dataframe_repository.py
+++ b/module1-data-ingestion/python-ingest/src/dataframe_repository.py
@@ -60,19 +60,19 @@ class SQLRepository(metaclass=ABCMeta):
 class GreenTaxiRepository(SQLRepository):
     @property
     def tbl_name(self) -> str:
-        return "green_taxi_data"
+        return "green_taxi_trips"
 
 
 class YellowTaxiRepository(SQLRepository):
     @property
     def tbl_name(self) -> str:
-        return "yellow_taxi_data"
+        return "yellow_taxi_trips"
 
 
 class FhvTaxiRepository(SQLRepository):
     @property
     def tbl_name(self) -> str:
-        return "fhv_taxi_data"
+        return "fhv_trips"
 
 
 class ZoneLookupRepository(SQLRepository):


### PR DESCRIPTION
### Summary

* Fix PostgreSQL tables names for nyc_taxi db 
  * green_taxi_data is now renamed to `green_taxi_trips`
  * yellow_taxi_data is now renamed to `yellow_taxi_trips`
  * fhv_taxi is now renamed to `fhv_trips`