### PR TITLE
fix/kafka-cluster 

### DIFF
--- a/module6-stream-processing/docker-compose.yml
+++ b/module6-stream-processing/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.9" 
 
-x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
-x-cp-zookeeper-image: &cp-zookeeper-image confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
-x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
-x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
-x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
-x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.4.3}
+x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
+x-cp-zookeeper-image: &cp-zookeeper-image confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
+x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
+x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
+x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
+x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.6.0}
 
 x-depends-on-kafka-brokers:
   depends_on: &depends-on-kafka-brokers
@@ -27,8 +27,8 @@ x-kafka-common:
   image: *cp-kafka-image
   environment: &kafka-common-env
     KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    KAFKA_INTER_BROKER_LISTENER_NAME: 'INTERNAL'
-    KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT'
+    KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT_INTERNAL'
+    KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT'
     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
     KAFKA_DELETE_TOPIC_ENABLE: true
@@ -36,17 +36,16 @@ x-kafka-common:
     zookeeper: 
       condition: service_healthy
   healthcheck:
-    test: ["CMD-SHELL", "cub kafka-ready -b localhost:9092 1 10 || exit 1"]
+    test: ["CMD-SHELL", "cub kafka-ready -b localhost:29092 1 10 || exit 1"]
     start_period: 10s
     interval: 5s
     timeout: 10s
     retries: 3
-  restart: on-failure
+  restart: on-failure:5
 
 x-ksqldb-common:
   &ksqldb-common
   image: *cp-ksqldb-server-image
-  restart: on-failure:5
   environment:
     &ksqldb-common-env
     KSQL_LISTENERS: 'http://0.0.0.0:8088'
@@ -54,11 +53,13 @@ x-ksqldb-common:
     KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: true
   depends_on:
     <<: *depends-on-kafka-brokers
+  restart: on-failure:5
 
 services:
   zookeeper:
     image: *cp-zookeeper-image
     container_name: zookeeper
+    hostname: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -73,53 +74,54 @@ services:
       interval: 10s
       timeout: 30s
       retries: 10
-    restart: on-failure
+    restart: on-failure:5
 
   broker0:
     <<: *kafka-common
     container_name: kafka_broker0
+    hostname: broker0
     environment:
       <<: *kafka-common-env
       KAFKA_BROKER_ID: 0
-      KAFKA_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29092'
-      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker0:29092'
     ports:
-      - '29092:29092'
+      - '9092:9092'
     volumes:
       - ${KAFKA_DATA:-./volumes/kafka}/broker0:/var/lib/kafka/data
 
   broker1:
     <<: *kafka-common
     container_name: kafka_broker1
+    hostname: broker1
     environment:
       <<: *kafka-common-env
       KAFKA_BROKER_ID: 1
-      KAFKA_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29192'
-      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29192'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9192,PLAINTEXT_INTERNAL://broker1:29092'
     ports:
-      - '29192:29192'
+      - '9192:9192'
     volumes:
       - ${KAFKA_DATA:-./volumes/kafka}/broker1:/var/lib/kafka/data
 
   broker2:
     <<: *kafka-common
     container_name: kafka_broker2
+    hostname: broker2
     environment:
       <<: *kafka-common-env
       KAFKA_BROKER_ID: 2
-      KAFKA_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29292'
-      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://:9092,EXTERNAL://:29292'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9292,PLAINTEXT_INTERNAL://broker2:29092'
     ports:
-      - '29292:29292'
+      - '9292:9292'
     volumes:
       - ${KAFKA_DATA:-./volumes/kafka}/broker2:/var/lib/kafka/data
 
   schemaregistry:
     image: *cp-schema-registry-image
     container_name: schemaregistry
+    hostname: schemaregistry
     environment:
       SCHEMA_REGISTRY_HOST_NAME: 'schemaregistry'
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://broker0:9092,PLAINTEXT://broker1:9092,PLAINTEXT://broker2:9092'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT_INTERNAL://broker0:29092,PLAINTEXT_INTERNAL://broker1:29092,PLAINTEXT_INTERNAL://broker2:29092'
       SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
       SCHEMA_REGISTRY_DEBUG: true
     ports:
@@ -131,14 +133,15 @@ services:
       interval: 5s
       timeout: 10s
       retries: 3
-    restart: on-failure
+    restart: on-failure:5
 
   kafkarest:
     image: *cp-restproxy-image
     container_name: kafkarest
+    hostname: kafkarest
     environment:
       KAFKA_REST_HOST_NAME: 'restproxy'
-      KAFKA_REST_BOOTSTRAP_SERVERS: 'PLAINTEXT://broker0:9092,PLAINTEXT://broker1:9092,PLAINTEXT://broker2:9092'
+      KAFKA_REST_BOOTSTRAP_SERVERS: 'PLAINTEXT_INTERNAL://broker0:29092,PLAINTEXT_INTERNAL://broker1:29092,PLAINTEXT_INTERNAL://broker2:29092'
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schemaregistry:8081'
       KAFKA_REST_LISTENERS: 'http://0.0.0.0:8082'
     ports:
@@ -150,15 +153,16 @@ services:
       interval: 5s
       timeout: 10s
       retries: 3
-    restart: on-failure
+    restart: on-failure:5
 
   ksqldb0:
     <<: *ksqldb-common
     container_name: ksqldb0
+    hostname: ksqldb0
     environment:
       <<: *ksqldb-common-env
       KSQL_KSQL_SERVICE_ID: 'ksqldb0'
-      KSQL_BOOTSTRAP_SERVERS: 'broker0:9092,broker1:9092,broker2:9092'
+      KSQL_BOOTSTRAP_SERVERS: 'broker0:29092,broker1:29092,broker2:29092'
       KSQL_KSQL_SCHEMA_REGISTRY_URL: 'http://schemaregistry:8081'
     ports:
       - '8088:8088'
@@ -168,35 +172,37 @@ services:
       interval: 10s
       timeout: 30s
       retries: 5
-    restart: on-failure
+    restart: on-failure:5
 
   ksqlcli:
     image: *cp-ksqldb-cli-image
     container_name: ksqlcli
+    hostname: ksqlcli
     entrypoint: /bin/bash
     tty: true
     depends_on:
       ksqldb0:
         condition: service_healthy
-    restart: on-failure
+    restart: on-failure:5
  
   # Conduktor Platform Docs:
   # - https://docs.conduktor.io/platform/configuration/env-variables
   # - https://docs.conduktor.io/platform/installation/hardware
   conduktor:
-    container_name: conduktor
     image: conduktor/conduktor-platform:1.17.3
+    container_name: conduktor
+    hostname: conduktor
     environment:
       CDK_CLUSTERS_0_ID: 'warp'
-      CDK_CLUSTERS_0_NAME: 'kafka-cluster-dev'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:9092,broker1:9092,broker2:9092'
-      CDK_CLUSTERS_0_SCHEMAREGISTRY_ID: 'warp-registry'
+      CDK_CLUSTERS_0_NAME: 'cp-kafka-in-docker'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
+      CDK_CLUSTERS_0_SCHEMAREGISTRY_ID: 'cp-schema-registry'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schemaregistry:8081'
       CDK_ADMIN_EMAIL: 'admin@conduktor.io'
-      CDK_ADMIN_PASSWORD: 'admin'
+      CDK_ADMIN_PASSWORD: 'conduktor'
       CDK_LISTENING_PORT: 8080
       RUN_MODE: nano
     ports:
       - '8080:8080'
     depends_on: *depends-on-kafka-cluster
-    restart: on-failure
+    restart: on-failure:5

--- a/module6-stream-processing/docker-compose.yml
+++ b/module6-stream-processing/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     hostname: schemaregistry
     environment:
       SCHEMA_REGISTRY_HOST_NAME: 'schemaregistry'
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT_INTERNAL://broker0:29092,PLAINTEXT_INTERNAL://broker1:29092,PLAINTEXT_INTERNAL://broker2:29092'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://broker0:29092,broker1:29092,broker2:29092'
       SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
       SCHEMA_REGISTRY_DEBUG: true
     ports:
@@ -141,7 +141,7 @@ services:
     hostname: kafkarest
     environment:
       KAFKA_REST_HOST_NAME: 'restproxy'
-      KAFKA_REST_BOOTSTRAP_SERVERS: 'PLAINTEXT_INTERNAL://broker0:29092,PLAINTEXT_INTERNAL://broker1:29092,PLAINTEXT_INTERNAL://broker2:29092'
+      KAFKA_REST_BOOTSTRAP_SERVERS: 'PLAINTEXT://broker0:29092,broker1:29092,broker2:29092'
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schemaregistry:8081'
       KAFKA_REST_LISTENERS: 'http://0.0.0.0:8082'
     ports:


### PR DESCRIPTION
## Summary
    
* Changes external port on kafka brokers to 9092, 9192, 9292, 
   and the internal port on all brokers to 29092

* Bumps all confluent components to 7.6.0    
* Fixes KAFKA_ADVERTISED_LISTENERS on broker0, broker1, broker2
* Fixes broker configuration on schemaregistry and kafkarest