### PR TITLE
fix/risingwave-docker-compose

### DIFF
--- a/module6-stream-processing/risingwave/README.md
+++ b/module6-stream-processing/risingwave/README.md
@@ -20,6 +20,7 @@
 ## Up & Running 
 
 ```shell
+docker compose -f docker-compose.kafka.yml up -d
 docker compose up -d 
 ```
 
@@ -34,6 +35,7 @@ In order to simulate real-time data, we will replace the `timestamp` fields in t
 
 Let's start ingestion into RisingWave by running it:
 ```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 python seed.py --use-streaming
 ```
 

--- a/module6-stream-processing/risingwave/docker-compose.clickhouse.yml
+++ b/module6-stream-processing/risingwave/docker-compose.clickhouse.yml
@@ -21,6 +21,8 @@ services:
       nofile:
         soft: 262144
         hard: 262144
+    networks:
+      - risingwave
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ || exit 1"]
       interval: 5s
@@ -33,3 +35,7 @@ volumes:
     name: clickhouse_data
   ch_logs:
     name: clickhouse_logs
+
+networks:
+  risingwave:
+    name: risingwave

--- a/module6-stream-processing/risingwave/docker-compose.kafka.yml
+++ b/module6-stream-processing/risingwave/docker-compose.kafka.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - ${ZK_DATA:-./volumes/zk_data}:/var/lib/zookeeper/data
       - ${ZK_LOGS:-./volumes/zk_logs}:/var/lib/zookeeper/log
+    networks:
+      - risingwave
     healthcheck:
       test: ["CMD-SHELL", "cub zk-ready localhost:2181 30 || exit 1"]
       interval: 10s
@@ -57,6 +59,9 @@ services:
       - '9092:9092'
     volumes:
       - ${KAFKA_DATA:-./volumes/kafka}/broker0:/var/lib/kafka/data
+    networks:
+      - risingwave
+
 
   kafka-init:
     <<: *kafka-common
@@ -68,6 +73,8 @@ services:
     depends_on:
       broker:
         condition: service_healthy
+    networks:
+      - risingwave
     command:
       "bash -c 'echo Kafka is ready, attempting to create topics... &&
       kafka-topics  --bootstrap-server broker:29092 --create --if-not-exists --topic yellow-taxi-tripdata --replication-factor 1 --partitions 8 &&
@@ -94,4 +101,10 @@ services:
     depends_on:
       broker:
         condition: service_healthy
+    networks:
+      - risingwave
     restart: on-failure:5
+
+networks:
+  risingwave:
+    name: risingwave

--- a/module6-stream-processing/risingwave/docker-compose.kafka.yml
+++ b/module6-stream-processing/risingwave/docker-compose.kafka.yml
@@ -44,15 +44,15 @@ services:
       retries: 10
     restart: on-failure:5
 
-  broker0:
+  broker:
     <<: *kafka-common
-    container_name: kafka-broker0
-    hostname: broker0
+    container_name: kafka-broker
+    hostname: broker
     environment:
       <<: *kafka-common-env
       KAFKA_BROKER_ID: 0
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker0:29092,OUTSIDE://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
     ports:
       - '9092:9092'
     volumes:
@@ -66,12 +66,12 @@ services:
       KAFKA_BROKER_ID: ignored
       KAFKA_ZOOKEEPER_CONNECT: ignored
     depends_on:
-      broker0:
+      broker:
         condition: service_healthy
     command:
       "bash -c 'echo Kafka is ready, attempting to create topics... &&
-      kafka-topics  --bootstrap-server broker0:29092 --create --if-not-exists --topic yellow-taxi-tripdata --replication-factor 1 --partitions 8 &&
-      kafka-configs --bootstrap-server broker0:29092 --alter --topic yellow-taxi-tripdata --add-config cleanup.policy=compact &&
+      kafka-topics  --bootstrap-server broker:29092 --create --if-not-exists --topic yellow-taxi-tripdata --replication-factor 1 --partitions 8 &&
+      kafka-configs --bootstrap-server broker:29092 --alter --topic yellow-taxi-tripdata --add-config cleanup.policy=delete &&
       echo Kafka setup is now done'"
 
   # Conduktor Platform Docs:
@@ -84,7 +84,7 @@ services:
     environment:
       CDK_CLUSTERS_0_ID: 'warp'
       CDK_CLUSTERS_0_NAME: 'cp-kafka-in-docker'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker:29092'
       CDK_ADMIN_EMAIL: 'conduktor@conduktor.io'
       CDK_ADMIN_PASSWORD: 'conduktor'
       CDK_LISTENING_PORT: 8080
@@ -92,6 +92,6 @@ services:
     ports:
       - '8080:8080'
     depends_on:
-      broker0:
+      broker:
         condition: service_healthy
     restart: on-failure:5

--- a/module6-stream-processing/risingwave/docker-compose.yml
+++ b/module6-stream-processing/risingwave/docker-compose.yml
@@ -1,7 +1,8 @@
----
 version: "3.9"
 
 x-risingwave-image: &risingwave-image risingwavelabs/risingwave:${RISINGWAVE_VERSION:-v1.6.1}
+x-etcd-image: &etcd-image quay.io/coreos/etcd:${ETCD_VERSION:-v3.5.10}
+x-minio-image: &minio-image quay.io/minio/minio:${MINIO_VERSION:-latest}
 
 services:
   risingwave:
@@ -19,16 +20,16 @@ services:
     volumes:
       - "./risingwave.toml:/risingwave.toml"
     depends_on:
-      - etcd-0
-      - minio-0
+      - etcd
+      - minio
     command: "standalone --meta-opts=\" \
                     --listen-addr 0.0.0.0:5690 \
                     --advertise-addr 0.0.0.0:5690 \
                     --dashboard-host 0.0.0.0:5691 \
                     --connector-rpc-endpoint 0.0.0.0:50051 \
                     --backend etcd \
-                    --etcd-endpoints etcd-0:2388 \
-                    --state-store hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001 \
+                    --etcd-endpoints etcd:2388 \
+                    --state-store hummock+minio://hummockadmin:hummockadmin@minio:9301/hummock001 \
                     --data-directory hummock_001 \
                     --config-path /risingwave.toml\" \
                  --compute-opts=\" \
@@ -62,22 +63,22 @@ services:
       timeout: 5s
     restart: on-failure:5
 
-  etcd-0:
-    image: "quay.io/coreos/etcd:v3.5.10"
+  etcd:
+    image: *etcd-image
     container_name: etcd
     hostname: etcd
     ports:
       - "2388:2388"
       - "2389:2389"
     volumes:
-      - "etcd-0:/etcd-data"
+      - "etcd-data:/etcd-data"
     command: 
       "/usr/local/bin/etcd \
         --listen-client-urls http://0.0.0.0:2388 \
         --listen-peer-urls http://0.0.0.0:2389 \
         --listen-metrics-urls http://0.0.0.0:2379 \
-        --advertise-client-urls http://etcd-0:2388 \
-        --initial-advertise-peer-urls http://etcd-0:2389 \
+        --advertise-client-urls http://etcd:2388 \
+        --initial-advertise-peer-urls http://etcd:2389 \
         --name risedev-meta \
         --max-txn-ops 999999 \
         --max-request-bytes 10485760 \
@@ -94,20 +95,20 @@ services:
         - health
     restart: on-failure:5
 
-  minio-0:
-    image: "quay.io/minio/minio:latest"
+  minio:
+    image: *minio-image
     container_name: minio
     hostname: minio
     environment:
       MINIO_CI_CD: "1"
       MINIO_ROOT_PASSWORD: hummockadmin
       MINIO_ROOT_USER: hummockadmin
-      MINIO_DOMAIN: "minio-0"
+      MINIO_DOMAIN: "minio"
     ports:
       - "9301:9301"
       - "9400:9400"
     volumes:
-      - "minio-0:/data"
+      - "minio-data:/data"
     entrypoint: "
       /bin/sh -c '
 
@@ -127,7 +128,7 @@ services:
     restart: on-failure:5
 
 volumes:
-  etcd-0:
-    external: false
-  minio-0:
-    external: false
+  etcd-data:
+    name: rw-etcd-data
+  minio-data:
+    name: rw-minio-data

--- a/module6-stream-processing/risingwave/docker-compose.yml
+++ b/module6-stream-processing/risingwave/docker-compose.yml
@@ -40,8 +40,8 @@ services:
                     --advertise-addr 0.0.0.0:5688 \
                     --async-stack-trace verbose \
                     --connector-rpc-endpoint 0.0.0.0:50051 \
-                    --parallelism 4 \
-                    --total-memory-bytes 8589934592 \
+                    # --parallelism 4 \
+                    # --total-memory-bytes 8589934592 \
                     --role both \
                     --meta-address http://0.0.0.0:5690\" \
                  --frontend-opts=\" \

--- a/module6-stream-processing/risingwave/docker-compose.yml
+++ b/module6-stream-processing/risingwave/docker-compose.yml
@@ -37,8 +37,8 @@ services:
                     --advertise-addr 0.0.0.0:5688 \
                     --async-stack-trace verbose \
                     --connector-rpc-endpoint 0.0.0.0:50051 \
-                    #--parallelism 4 \
-                    #--total-memory-bytes 8589934592 \
+                    --parallelism 4 \
+                    --total-memory-bytes 8589934592 \
                     --role both \
                     --meta-address http://0.0.0.0:5690\" \
                  --frontend-opts=\" \
@@ -58,7 +58,7 @@ services:
         - bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/5688; exit $$?;'
         - bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/4566; exit $$?;'
         - bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/5690; exit $$?;'
-      interval: 1s
+      interval: 5s
       timeout: 5s
     restart: on-failure:5
 
@@ -71,32 +71,20 @@ services:
       - "2389:2389"
     volumes:
       - "etcd-0:/etcd-data"
-    command:
-      - /usr/local/bin/etcd
-      - "--listen-client-urls"
-      - "http://0.0.0.0:2388"
-      - "--advertise-client-urls"
-      - "http://etcd-0:2388"
-      - "--listen-peer-urls"
-      - "http://0.0.0.0:2389"
-      - "--initial-advertise-peer-urls"
-      - "http://etcd-0:2389"
-      - "--listen-metrics-urls"
-      - "http://0.0.0.0:2379"
-      - "--name"
-      - risedev-meta
-      - "--max-txn-ops"
-      - "999999"
-      - "--max-request-bytes"
-      - "10485760"
-      - "--auto-compaction-mode"
-      - periodic
-      - "--auto-compaction-retention"
-      - 1m
-      - "--snapshot-count"
-      - "10000"
-      - "--data-dir"
-      - /etcd-data
+    command: 
+      "/usr/local/bin/etcd \
+        --listen-client-urls http://0.0.0.0:2388 \
+        --listen-peer-urls http://0.0.0.0:2389 \
+        --listen-metrics-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://etcd-0:2388 \
+        --initial-advertise-peer-urls http://etcd-0:2389 \
+        --name risedev-meta \
+        --max-txn-ops 999999 \
+        --max-request-bytes 10485760 \
+        --auto-compaction-mode periodic \
+        --auto-compaction-retention 1m \
+        --snapshot-count 10000 \ 
+        --data-dir /etcd-data"
     healthcheck:
       test:
         - CMD
@@ -104,9 +92,6 @@ services:
         - --endpoints=http://localhost:2388
         - endpoint
         - health
-      interval: 1s
-      timeout: 5s
-      retries: 5
     restart: on-failure:5
 
   minio-0:
@@ -123,24 +108,20 @@ services:
       - "9400:9400"
     volumes:
       - "minio-0:/data"
-    command:
-      - server
-      - "--address"
-      - "0.0.0.0:9301"
-      - "--console-address"
-      - "0.0.0.0:9400"
-      - /data
     entrypoint: "
       /bin/sh -c '
+
       set -e
+
       mkdir -p \"/data/hummock001\"
+
       /usr/bin/docker-entrypoint.sh \"$$0\" \"$$@\"
+
       '"
+    command: "server --address 0.0.0.0:9301 --console-address 0.0.0.0:9400 /data"
     healthcheck:
-      test:
-        - CMD-SHELL
-        - bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/9301; exit $$?;'
-      interval: 1s
+      test: ["CMD-SHELL", "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/9301; exit $$?;'"]
+      interval: 5s
       timeout: 5s
       retries: 5
     restart: on-failure:5

--- a/module6-stream-processing/risingwave/docker-compose.yml
+++ b/module6-stream-processing/risingwave/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     depends_on:
       - etcd
       - minio
+    networks:
+      - risingwave
     command: "standalone --meta-opts=\" \
                     --listen-addr 0.0.0.0:5690 \
                     --advertise-addr 0.0.0.0:5690 \
@@ -72,6 +74,8 @@ services:
       - "2389:2389"
     volumes:
       - "etcd-data:/etcd-data"
+    networks:
+      - risingwave
     command: 
       "/usr/local/bin/etcd \
         --listen-client-urls http://0.0.0.0:2388 \
@@ -109,6 +113,8 @@ services:
       - "9400:9400"
     volumes:
       - "minio-data:/data"
+    networks:
+      - risingwave
     entrypoint: "
       /bin/sh -c '
 
@@ -132,3 +138,7 @@ volumes:
     name: rw-etcd-data
   minio-data:
     name: rw-minio-data
+
+networks:
+  risingwave:
+    name: risingwave

--- a/module6-stream-processing/risingwave/risingwave.toml
+++ b/module6-stream-processing/risingwave/risingwave.toml
@@ -1,0 +1,2 @@
+# RisingWave config file to be mounted into the Docker containers.
+# See src/config/example.toml for example

--- a/module6-stream-processing/risingwave/sql/risingwave/table/yellow_taxi_trips.sql
+++ b/module6-stream-processing/risingwave/sql/risingwave/table/yellow_taxi_trips.sql
@@ -24,5 +24,6 @@ create table if not exists yellow_taxi_trips (
 ) with (
     connector='kafka',
     topic='yellow-taxi-tripdata',
-    properties.bootstrap.server='host.docker.internal:9092'
+    properties.bootstrap.server='broker:29092',
+    scan.startup.mode='earliest'
 ) format plain encode json;


### PR DESCRIPTION
## Summary

* Adds network risingwave to all components
* Disable `paralelism` and `total_memory_bytes` on RisingWave's docker-compose.yml
* Renames `etcd-0` to `etcd` and `minio-0` to `minio` on docker-compose.yml
* Renames `broker0` to `broker` on docker-compose.kafka.yml
* Update README instructions