### PR TITLE
refactor/datavis-infra: Updates docker compose files for Metabase/Superset

### DIFF
--- a/module4-analytics-engineering/datavis/README.md
+++ b/module4-analytics-engineering/datavis/README.md
@@ -22,30 +22,28 @@
 
 **0.** (Optional) Pre-loaded examples (demo charts/dashboards):
 
-Superset can be bootstrapped with pre-loaded example charts and dashboards. In order to enable that:
+Superset can be bootstrapped withexample charts and dashboards. In order to enable that, set:
 ```shell
 export SUPERSET_LOAD_EXAMPLES=yes
 ```
 
-Database Migrations and `load_examples` processes are run everytime by the initContainer `superset-init` in [docker-compose.yml file](./docker-compose.yml), which all other superset-services depend on. 
-
-Be sure to `unset SUPERSET_LOAD_EXAMPLES` or `export SUPERSET_LOAD_EXAMPLES=no` after the first run of `superset-init` is completed successfully, as the `load_examples` alone might take a few minutes.
+Make sure to: `unset SUPERSET_LOAD_EXAMPLES` or `export SUPERSET_LOAD_EXAMPLES=no`  after the **first run** of `superset-init` is completed successfully, as `load_examples` alone can take a few minutes.
 
 **1.** Spin up Apache Superset infrastructure with:
 ```shell
-docker compose -f docker-compose.superset.yml up -d
+docker compose -f compose.superset.yaml up -d
 ```
 
 **2.** Additional database drivers:
 
-Superset supports PostgreSQL, MySQL and out-of-the-box. To enable additional data sources, include the respective SQLAlchemy driver as a dependency on [requirements-local.txt](./superset/requirements-local.txt). 
+Superset supports PostgreSQL, MySQL and out-of-the-box. To enable additional data sources, include the respective `SQLAlchemy` driver as a dependency in [requirements-local.txt](./superset/requirements-local.txt). 
 
-The complete list of supported data sources can be found [here](https://superset.apache.org/docs/databases/installing-database-drivers/).
+A complete list of supported data sources can be found [here](https://superset.apache.org/docs/databases/installing-database-drivers/).
 
 ```python
-sqlalchemy-bigquery==1.9.0
+sqlalchemy-bigquery==1.11.0
 sqlalchemy-redshift==0.8.14
-clickhouse-connect==0.6.23
+clickhouse-connect==0.7.16
 ```
 
 **3.** After the `superset_app` container is in a healthy state, you can acccess Superset at:

--- a/module4-analytics-engineering/datavis/README.md
+++ b/module4-analytics-engineering/datavis/README.md
@@ -46,7 +46,7 @@ sqlalchemy-redshift==0.8.14
 clickhouse-connect==0.7.16
 ```
 
-**3.** After the `superset_app` container is in a healthy state, you can acccess Superset at:
+**3.** After the `superset-app` container is in a healthy state, you can acccess Superset at:
 ```shell
 open http://localhost:8088/
 ```
@@ -57,9 +57,8 @@ open http://localhost:8088/
 **1.** Spin up Metabase infrastructure with:
 
 ```shell
-docker compose -f docker-compose.metabase.yml up -d
+docker compose -f compose.metabase.yaml up -d
 ```
-
 
 **2.** Additional database drivers:
 
@@ -68,7 +67,7 @@ Metabase supports a wide-variety of data sources out-of-the-box (BigQuery, RedSh
 For Partners Data Sources and Community Data Source connectors, such as `ClickHouse`, however, additional JDBC drivers have to be downloaded and put in the `plugins` folders, which is exactly what the `metabase-init` container is for.
 
 
-**3.** After the `metabase_app` container is in a healthy state, you can acccess Metabase at:
+**3.** After the `metabase-app` container is in a healthy state, you can acccess Metabase at:
 ```shell
 open http://localhost:3000/
 ```

--- a/module4-analytics-engineering/datavis/compose.metabase.yaml
+++ b/module4-analytics-engineering/datavis/compose.metabase.yaml
@@ -1,7 +1,5 @@
-version: "3.9"
-
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
-x-metabase-image: &metabase-image metabase/metabase:${METABASE_VERSION:-latest}
+x-metabase-image: &metabase-image metabase/metabase:${METABASE_VERSION:-v0.50.12}
 
 x-metabase-common: &metabase-common
   image: *metabase-image
@@ -32,7 +30,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - metabase_pg_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -66,13 +64,12 @@ services:
       - -c
       - |
         mkdir -p $${MB_PLUGINS_DIR}
-        curl -L -o $${MB_PLUGINS_DIR}/clickhouse.metabase-driver.jar https://github.com/ClickHouse/metabase-clickhouse-driver/releases/download/1.3.3/clickhouse.metabase-driver.jar
+        curl -L -o $${MB_PLUGINS_DIR}/clickhouse.metabase-driver.jar https://github.com/ClickHouse/metabase-clickhouse-driver/releases/download/1.50.1/clickhouse.metabase-driver.jar
         chown -R $${MUID}:$${MGID} $${MB_PLUGINS_DIR}
 
-
 volumes:
-  pg_data:
-    name: metabase_pgdata
+  metabase_pg_data:
+    name: metabase_pg_data
   metabase_data:
     name: metabase_data
   metabase_plugins:

--- a/module4-analytics-engineering/datavis/compose.metabase.yaml
+++ b/module4-analytics-engineering/datavis/compose.metabase.yaml
@@ -22,7 +22,7 @@ x-metabase-common: &metabase-common
 services:
   metabase-db:
     image: *postgres-image
-    container_name: metabase_db
+    container_name: metabase-db
     environment:
       POSTGRES_USER: 'metabase'
       POSTGRES_PASSWORD: 'metabase'
@@ -40,7 +40,7 @@ services:
 
   metabase:
     <<: *metabase-common
-    container_name: metabase_app
+    container_name: metabase-app
     ports:
       - 3000:3000
     depends_on:
@@ -57,7 +57,7 @@ services:
 
   metabase-init:
     <<: *metabase-common
-    container_name: metabase_init
+    container_name: metabase-init
     user: "0:0"
     entrypoint: /bin/bash
     command:

--- a/module4-analytics-engineering/datavis/compose.superset.yaml
+++ b/module4-analytics-engineering/datavis/compose.superset.yaml
@@ -1,8 +1,10 @@
-version: "3.9"
+x-superset-image: &superset-image apache/superset:${SUPERSET_VERSION:-4.0.0}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
+x-redis-image: &redis-image redis:${REDIS_VERSION:-7.2.5}
 
 x-superset-common:
   &superset-common
-  image: apachesuperset.docker.scarf.sh/apache/superset:${TAG:-latest-dev}
+  image: *superset-image
   user: 'root'
   environment:
     &superset-common-env
@@ -44,7 +46,7 @@ x-superset-common:
 
 services:
   superset-db:
-    image: postgres:16-alpine
+    image: *postgres-image
     container_name: superset_db
     environment:
       POSTGRES_DB: 'superset'
@@ -66,7 +68,7 @@ services:
     restart: on-failure
 
   superset-cache:
-    image: redis:7.2
+    image: *redis-image
     container_name: superset_cache
     ports:
       - '6379'

--- a/module4-analytics-engineering/datavis/compose.superset.yaml
+++ b/module4-analytics-engineering/datavis/compose.superset.yaml
@@ -47,7 +47,7 @@ x-superset-common:
 services:
   superset-db:
     image: *postgres-image
-    container_name: superset_db
+    container_name: superset-db
     environment:
       POSTGRES_DB: 'superset'
       POSTGRES_USER: 'superset'
@@ -58,7 +58,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - superset_pgdata:/var/lib/postgresql/data
+      - superset_pg_data:/var/lib/postgresql/data
       - ./superset/examples-init.sh:/docker-entrypoint-initdb.d/examples-init.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U superset"]
@@ -69,7 +69,7 @@ services:
 
   superset-cache:
     image: *redis-image
-    container_name: superset_cache
+    container_name: superset-cache
     ports:
       - '6379'
     volumes:
@@ -83,7 +83,7 @@ services:
 
   superset:
     <<: *superset-common
-    container_name: superset_app
+    container_name: superset-app
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
     ports:
       - 8088:8088
@@ -95,7 +95,7 @@ services:
 
   superset-worker:
     <<: *superset-common
-    container_name: superset_worker
+    container_name: superset-worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     depends_on:
       <<: *superset-common-depends-on
@@ -107,7 +107,7 @@ services:
 
   superset-worker-beat:
     <<: *superset-common
-    container_name: superset_worker_beat
+    container_name: superset-worker-beat
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
     depends_on:
       <<: *superset-common-depends-on
@@ -119,7 +119,7 @@ services:
 
   superset-init:
     <<: *superset-common
-    container_name: superset_init
+    container_name: superset-init
     command: ["/app/docker/docker-init.sh"]
     healthcheck:
       disable: true
@@ -127,7 +127,7 @@ services:
 volumes:
   superset_home:
     name: 'superset_home'
-  superset_pgdata:
-    name: 'superset_pgdata'
+  superset_pg_data:
+    name: 'superset_pg_data'
   superset_redis_cache:
     name: 'superset_redis_cache'

--- a/module4-analytics-engineering/datavis/superset/requirements-local.txt
+++ b/module4-analytics-engineering/datavis/superset/requirements-local.txt
@@ -1,3 +1,3 @@
-sqlalchemy-bigquery==1.9.0
+sqlalchemy-bigquery==1.11.0
 sqlalchemy-redshift==0.8.14
-clickhouse-connect==0.6.23
+clickhouse-connect==0.7.16


### PR DESCRIPTION
## Summary

* Updates docker compose for Apache Superset
  * Pin the Superset docker image to ver 4.0.0 (arm)
  * Updates requirements-local.txt with the latest drivers 
     for bigquery, redshift and clickhouse
  * Update running instructions for Superset on README
* Updates docker compose for Metabase
  * Pin the Superset docker image to ver v0.50.12
  * Update running instructions for Metabaset on README