### PR TITLE
chore: Bumps Airflow Docker to 2.10

### DIFF
--- a/module2-workflow-orchestration/airflow/compose.celery.yaml
+++ b/module2-workflow-orchestration/airflow/compose.celery.yaml
@@ -1,4 +1,4 @@
-x-airflow-image: &airflow-image apache/airflow:${AIRFLOW_VERSION:-2.9.3-python3.11}
+x-airflow-image: &airflow-image apache/airflow:${AIRFLOW_VERSION:-2.10.0-python3.12}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
 x-redis-image: &redis-image redis:${REDIS_VERSION:-7.4.0-alpine}
 

--- a/module2-workflow-orchestration/airflow/compose.local.yaml
+++ b/module2-workflow-orchestration/airflow/compose.local.yaml
@@ -1,4 +1,4 @@
-x-airflow-image: &airflow-image apache/airflow:${AIRFLOW_VERSION:-2.9.3-python3.11}
+x-airflow-image: &airflow-image apache/airflow:${AIRFLOW_VERSION:-2.10.0-python3.12}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
 
 x-airflow-common:


### PR DESCRIPTION
## Summary

* Bumps Airflow Docker Image to 2.10