### PR TITLE
chore/update-streaming-infra

### DIFF
--- a/module6-stream-processing/README.md
+++ b/module6-stream-processing/README.md
@@ -29,20 +29,27 @@ Hop into their respective folders for details on how to spin them up.
 
 ### Developer Setup
 
-**1.** Start the Kafka Cluster (Single broker setup with KRaft):
+**1.** Spin up Kafka Broker with one of the following options:
+
+1.1. Kafka Cluster (Single-broker) with KRaft:
 ```shell
 docker compose up -d
 ```
 
-Alternatively, you can use the multi-broker setup with:
+1.2. Kafka Cluster (Multi-broker) with KRaft:
 ```shell
-# For Kafka+KRaft
 docker compose -f compose.kraft-multi-broker.yaml up -d
+```
 
-# for Kafka with Zookeeper
+1.3. Kafka Cluster (Multi-broker) with Zookeeper:
+```shell
 docker compose -f compose.zookeeper-multi-broker.yaml up -d
 ```
 
+1.4. Redpanda:
+```shell
+docker compose -f compose.redpanda.yaml up -d
+```
 
 **2.** Access Conduktor Web UI for Kafka
 ```shell

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -186,8 +186,8 @@ services:
     hostname: conduktor-console
     environment:
       CDK_CLUSTERS_0_ID: 'kafka-kraft-in-docker'
-      CDK_CLUSTERS_0_NAME: 'single-broker-kraft-kafka'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
+      CDK_CLUSTERS_0_NAME: 'multi-broker-kraft-kafka'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -4,8 +4,8 @@ x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUEN
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.27.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.28.0}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
   &kafka-common
@@ -186,12 +186,13 @@ services:
     hostname: conduktor-console
     environment:
       CDK_CLUSTERS_0_ID: 'kafka-kraft-in-docker'
-      CDK_CLUSTERS_0_NAME: 'multi-broker-kraft-kafka'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
+      CDK_CLUSTERS_0_NAME: 'single-broker-kraft-kafka'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-db:5432/conduktor"
+      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
       CDK_LISTENING_PORT: 8080
     ports:
       - '8080:8080'
@@ -199,14 +200,16 @@ services:
       - conduktor_data:/var/conduktor
     depends_on:
       <<: *depends-on-kafka-cluster
-      conduktor-db:
+      conduktor-metastore:
+        condition: service_healthy
+      conduktor-sql:
         condition: service_healthy
     restart: on-failure:5
 
-  conduktor-db:
+  conduktor-metastore:
     image: *postgres-image
-    container_name: conduktor-db
-    hostname: postgresql
+    container_name: conduktor-metastore
+    hostname: conduktor-metastore
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
@@ -215,7 +218,27 @@ services:
     ports:
       - '5432'
     volumes:
-      - conduktor_pg_data:/var/lib/postgresql/data
+      - conduktor_metadata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: on-failure:5
+
+  conduktor-sql:
+    image: *postgres-image
+    container_name: conduktor-sql
+    hostname: conduktor-sql
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
+    ports:
+      - '5432'
+    volumes:
+      - conduktor_sql:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -226,5 +249,7 @@ services:
 volumes:
   conduktor_data:
     name: conduktor_data
-  conduktor_pg_data:
-    name: conduktor_pg_data
+  conduktor_metadata:
+    name: conduktor_metadata
+  conduktor_sql:
+    name: conduktor_sql

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -4,8 +4,8 @@ x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUEN
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.27.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.28.0}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
   &kafka-common
@@ -155,7 +155,8 @@ services:
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-db:5432/conduktor"
+      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
       CDK_LISTENING_PORT: 8080
     ports:
       - '8080:8080'
@@ -163,14 +164,16 @@ services:
       - conduktor_data:/var/conduktor
     depends_on:
       <<: *depends-on-kafka-cluster
-      conduktor-db:
+      conduktor-metastore:
+        condition: service_healthy
+      conduktor-sql:
         condition: service_healthy
     restart: on-failure:5
 
-  conduktor-db:
+  conduktor-metastore:
     image: *postgres-image
-    container_name: conduktor-db
-    hostname: postgresql
+    container_name: conduktor-metastore
+    hostname: conduktor-metastore
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
@@ -179,7 +182,27 @@ services:
     ports:
       - '5432'
     volumes:
-      - conduktor_pg_data:/var/lib/postgresql/data
+      - conduktor_metadata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: on-failure:5
+
+  conduktor-sql:
+    image: *postgres-image
+    container_name: conduktor-sql
+    hostname: conduktor-sql
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
+    ports:
+      - '5432'
+    volumes:
+      - conduktor_sql:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -190,5 +213,7 @@ services:
 volumes:
   conduktor_data:
     name: conduktor_data
-  conduktor_pg_data:
-    name: conduktor_pg_data
+  conduktor_metadata:
+    name: conduktor_metadata
+  conduktor_sql:
+    name: conduktor_sql

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -1,30 +1,36 @@
-x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v23.3.18}
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.27.0}
+x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.2.7}
 
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.28.0}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 services:
   # Redpanda Setup 
   ### 9092 - Redpanda Broker
   ### 8081 - Schema Registry (doesn't support JSON)
   ### 8082 - REST Proxy
-  broker-0:
+  broker0:
     image: *redpanda-image
-    container_name: broker-0
-    hostname: broker-0
+    container_name: broker0
+    hostname: broker0
     command:
       - redpanda start
       - --smp 1
       - --overprovisioned
       - --node-id 0
-      - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-      - --advertise-kafka-addr PLAINTEXT://broker-0:29092,OUTSIDE://localhost:9092
+      - --kafka-addr INTERNAL://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr INTERNAL://broker0:29092,OUTSIDE://localhost:9092
       - --pandaproxy-addr 0.0.0.0:8082
       - --advertise-pandaproxy-addr localhost:8082
     ports:
       - '9092:9092'
       - '8081:8081'
       - '8082:8082'
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health -e || exit 1"]
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 5
     restart: on-failure:5
 
   # Conduktor Platform Docs:
@@ -34,25 +40,26 @@ services:
     container_name: conduktor-console
     hostname: conduktor-console
     environment:
-      CDK_CLUSTERS_0_ID: 'kafka-in-docker'
-      CDK_CLUSTERS_0_NAME: 'single-broker-kafka'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker-0:29092'
-      CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://broker-0:8081'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-db:5432/conduktor"
+      CDK_CLUSTERS_0_ID: 'redpanda-in-docker'
+      CDK_CLUSTERS_0_NAME: 'single-broker-redpanda'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
+      CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://broker0:8081'
+      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
       CDK_LISTENING_PORT: 8080
     ports:
       - '8080:8080'
     volumes:
       - conduktor_data:/var/conduktor
     depends_on:
-      broker-0:
+      broker0:
         condition: service_started
     restart: on-failure:5
 
-  conduktor-db:
+  conduktor-metastore:
     image: *postgres-image
-    container_name: conduktor-db
-    hostname: postgresql
+    container_name: conduktor-metastore
+    hostname: conduktor-metastore
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
@@ -61,7 +68,27 @@ services:
     ports:
       - '5432'
     volumes:
-      - conduktor_pg_data:/var/lib/postgresql/data
+      - conduktor_metadata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: on-failure:5
+
+  conduktor-sql:
+    image: *postgres-image
+    container_name: conduktor-sql
+    hostname: conduktor-sql
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
+    ports:
+      - '5432'
+    volumes:
+      - conduktor_sql:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -72,5 +99,7 @@ services:
 volumes:
   conduktor_data:
     name: conduktor_data
-  conduktor_pg_data:
-    name: conduktor_pg_data
+  conduktor_metadata:
+    name: conduktor_metadata
+  conduktor_sql:
+    name: conduktor_sql

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -1,12 +1,12 @@
-x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-zookeeper-image: &cp-zookeeper-image confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
+x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.1}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.27.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-16-alpine}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.28.0}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
   &kafka-common
@@ -204,13 +204,14 @@ services:
     container_name: conduktor-console
     hostname: conduktor-console
     environment:
-      CDK_CLUSTERS_0_ID: 'kafka-in-docker'
-      CDK_CLUSTERS_0_NAME: 'multi-broker-kafka'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
+      CDK_CLUSTERS_0_ID: 'kafka-kraft-in-docker'
+      CDK_CLUSTERS_0_NAME: 'single-broker-kraft-kafka'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-db:5432/conduktor"
+      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
       CDK_LISTENING_PORT: 8080
     ports:
       - '8080:8080'
@@ -218,14 +219,16 @@ services:
       - conduktor_data:/var/conduktor
     depends_on:
       <<: *depends-on-kafka-cluster
-      conduktor-db:
+      conduktor-metastore:
+        condition: service_healthy
+      conduktor-sql:
         condition: service_healthy
     restart: on-failure:5
 
-  conduktor-db:
+  conduktor-metastore:
     image: *postgres-image
-    container_name: conduktor-db
-    hostname: postgresql
+    container_name: conduktor-metastore
+    hostname: conduktor-metastore
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
@@ -234,7 +237,27 @@ services:
     ports:
       - '5432'
     volumes:
-      - conduktor_pg_data:/var/lib/postgresql/data
+      - conduktor_metadata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: on-failure:5
+
+  conduktor-sql:
+    image: *postgres-image
+    container_name: conduktor-sql
+    hostname: conduktor-sql
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
+    ports:
+      - '5432'
+    volumes:
+      - conduktor_sql:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -245,5 +268,7 @@ services:
 volumes:
   conduktor_data:
     name: conduktor_data
-  conduktor_pg_data:
-    name: conduktor_pg_data
+  conduktor_metadata:
+    name: conduktor_metadata
+  conduktor_sql:
+    name: conduktor_sql

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -204,9 +204,9 @@ services:
     container_name: conduktor-console
     hostname: conduktor-console
     environment:
-      CDK_CLUSTERS_0_ID: 'kafka-kraft-in-docker'
-      CDK_CLUSTERS_0_NAME: 'single-broker-kraft-kafka'
-      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
+      CDK_CLUSTERS_0_ID: 'kafka-in-docker'
+      CDK_CLUSTERS_0_NAME: 'multi-broker-kafka'
+      CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'


### PR DESCRIPTION
## Summary

* Bumps conduktor-console to 1.28 to enable SQL queries on Kafka topics
* Bumps postgresql base image to `17-alpine`
* Adds `conduktor-sql` container to enable SQL queries on Kafka
* Renames conduktor-db to conduktor-metastore
* Updates `compose.redpanda.yaml`: adds healthcheck to `broker0`