### PR TITLE
update: Kafka Docker volumes & bumps confluent-platform

### DIFF
--- a/module6-stream-processing/README.md
+++ b/module6-stream-processing/README.md
@@ -1,6 +1,6 @@
 # Stream processing with Kafka & ksqlDB
 
-![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.7-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
+![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.8-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
 ![Docker](https://img.shields.io/badge/Docker-329DEE?style=flat&logo=docker&logoColor=white&labelColor=329DEE)
 
 ![License](https://img.shields.io/badge/license-CC--BY--SA--4.0-31393F?style=flat&logo=creativecommons&logoColor=black&labelColor=white)

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -1,8 +1,8 @@
-x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
+x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
 x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -4,8 +4,8 @@ x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUEN
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
-x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
+x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
@@ -76,7 +76,7 @@ services:
     ports:
       - '9092:9092'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker0:/var/lib/kafka/data
+      - vol-kafka-broker0:/var/lib/kafka/data
 
   broker1:
     <<: *kafka-common
@@ -91,7 +91,7 @@ services:
     ports:
       - '9192:9192'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker1:/var/lib/kafka/data
+      - vol-kafka-broker1:/var/lib/kafka/data
 
   broker2:
     <<: *kafka-common
@@ -106,7 +106,7 @@ services:
     ports:
       - '9292:9292'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker2:/var/lib/kafka/data
+      - vol-kafka-broker2:/var/lib/kafka/data
 
   schema-registry:
     image: *cp-schema-registry-image
@@ -195,8 +195,8 @@ services:
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
       CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
       CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
-      CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
-      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
+      CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
+      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
       CDK_MONITORING_NOTIFICATIONS-CALLBACK-URL: http://localhost:8080
       CDK_LISTENING_PORT: 8080
@@ -224,7 +224,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metadata:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -252,8 +252,9 @@ services:
       retries: 5
     restart: on-failure:5
 
-  conduktor-monitoring:
-    image: *conduktor-monitoring-image
+  conduktor-cortex:
+    image: *conduktor-cortex-image
+    container_name: conduktor-cortex
     environment:
       CDK_CONSOLE-URL: "http://conduktor-console:8080"
     ports:
@@ -263,9 +264,15 @@ services:
     restart: on-failure:5
 
 volumes:
+  vol-kafka-broker0:
+      name: vol-kafka-broker0
+  vol-kafka-broker1:
+      name: vol-kafka-broker1
+  vol-kafka-broker2:
+      name: vol-kafka-broker2
   vol-conduktor-data:
     name: vol-conduktor-data
-  vol-conduktor-metadata:
-    name: vol-conduktor-metadata
+  vol-conduktor-metastore:
+    name: vol-conduktor-metastore
   vol-conduktor-sql:
     name: vol-conduktor-sql

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -138,7 +138,7 @@ services:
     ports:
       - '8088:8088'
     volumes:
-      - ${KSQL_UDF_EXTENSIONS_DIR:-./volumes/ksqldb-udf}:/opt/ksqldb-udf
+      - vol-ksqldb-udf:/opt/ksqldb-udf
     depends_on:
       <<: *depends-on-kafka-cluster
     healthcheck:
@@ -270,6 +270,8 @@ volumes:
       name: vol-kafka-broker1
   vol-kafka-broker2:
       name: vol-kafka-broker2
+  vol-ksqldb-udf:
+    name: vol-ksqldb-udf
   vol-conduktor-data:
     name: vol-conduktor-data
   vol-conduktor-metastore:

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -1,8 +1,8 @@
-x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
+x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
 x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -4,8 +4,8 @@ x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUEN
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
-x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
+x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
@@ -68,7 +68,7 @@ services:
     ports:
       - '9092:9092'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker0:/var/lib/kafka/data
+      - vol-kafka-broker0:/var/lib/kafka/data
 
   schema-registry:
     image: *cp-schema-registry-image
@@ -159,8 +159,8 @@ services:
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
       CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
       CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
-      CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
-      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
+      CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
+      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
       CDK_MONITORING_NOTIFICATIONS-CALLBACK-URL: http://localhost:8080
       CDK_LISTENING_PORT: 8080
@@ -188,7 +188,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metadata:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -216,8 +216,9 @@ services:
       retries: 5
     restart: on-failure:5
 
-  conduktor-monitoring:
-    image: *conduktor-monitoring-image
+  conduktor-cortex:
+    image: *conduktor-cortex-image
+    container_name: conduktor-cortex
     environment:
       CDK_CONSOLE-URL: "http://conduktor-console:8080"
     ports:
@@ -227,9 +228,11 @@ services:
     restart: on-failure:5
 
 volumes:
+  vol-kafka-broker0:
+      name: vol-kafka-broker0
   vol-conduktor-data:
     name: vol-conduktor-data
-  vol-conduktor-metadata:
-    name: vol-conduktor-metadata
+  vol-conduktor-metastore:
+    name: vol-conduktor-metastore
   vol-conduktor-sql:
     name: vol-conduktor-sql

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -102,7 +102,7 @@ services:
     ports:
       - '8088:8088'
     volumes:
-      - ${KSQL_UDF_EXTENSIONS_DIR:-./volumes/ksqldb-udf}:/opt/ksqldb-udf
+      - vol-ksqldb-udf:/opt/ksqldb-udf
     depends_on: 
       <<: *depends-on-kafka-cluster
     healthcheck:
@@ -230,6 +230,8 @@ services:
 volumes:
   vol-kafka-broker0:
       name: vol-kafka-broker0
+  vol-ksqldb-udf:
+    name: vol-ksqldb-udf
   vol-conduktor-data:
     name: vol-conduktor-data
   vol-conduktor-metastore:

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -1,4 +1,4 @@
-x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.3.1}
+x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.2.13}
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
 x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -1,7 +1,7 @@
 x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.3.1}
 
-x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
+x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 services:
@@ -69,7 +69,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metadata:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -97,8 +97,9 @@ services:
       retries: 5
     restart: on-failure:5
 
-  conduktor-monitoring:
-    image: *conduktor-monitoring-image
+  conduktor-cortex:
+    image: *conduktor-cortex-image
+    container_name: conduktor-cortex
     environment:
       CDK_CONSOLE-URL: "http://conduktor-console:8080"
     ports:
@@ -110,7 +111,7 @@ services:
 volumes:
   vol-conduktor-data:
     name: vol-conduktor-data
-  vol-conduktor-metadata:
-    name: vol-conduktor-metadata
+  vol-conduktor-metastore:
+    name: vol-conduktor-metastore
   vol-conduktor-sql:
     name: vol-conduktor-sql

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -1,4 +1,4 @@
-x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.2.12}
+x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v24.3.1}
 
 x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -5,8 +5,8 @@ x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUEN
 x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
-x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
-x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
+x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
+x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.2}
 x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
 
 x-kafka-common:
@@ -76,8 +76,8 @@ services:
     ports:
       - '2181:2181'
     volumes:
-      - ${ZK_DATA:-./volumes/zk_data}:/var/lib/zookeeper/data
-      - ${ZK_LOGS:-./volumes/zk_logs}:/var/lib/zookeeper/log
+      - vol-zk-data:/var/lib/zookeeper/data
+      - vol-zk-logs:/var/lib/zookeeper/log
     healthcheck:
       test: ["CMD-SHELL", "cub zk-ready localhost:2181 30 || exit 1"]
       interval: 10s
@@ -97,7 +97,7 @@ services:
     ports:
       - '9092:9092'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker0:/var/lib/kafka/data
+      - vol-kafka-broker0:/var/lib/kafka/data
 
   broker1:
     <<: *kafka-common
@@ -111,7 +111,7 @@ services:
     ports:
       - '9192:9192'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker1:/var/lib/kafka/data
+      - vol-kafka-broker1:/var/lib/kafka/data
 
   broker2:
     <<: *kafka-common
@@ -125,7 +125,7 @@ services:
     ports:
       - '9292:9292'
     volumes:
-      - ${KAFKA_DATA:-./volumes/kafka}/broker2:/var/lib/kafka/data
+      - vol-kafka-broker2:/var/lib/kafka/data
 
   schema-registry:
     image: *cp-schema-registry-image
@@ -206,16 +206,16 @@ services:
     container_name: conduktor-console
     hostname: conduktor-console
     environment:
-      CDK_CLUSTERS_0_ID: 'kafka-in-docker'
-      CDK_CLUSTERS_0_NAME: 'multi-broker-kafka'
+      CDK_CLUSTERS_0_ID: 'kafka-zk-in-docker'
+      CDK_CLUSTERS_0_NAME: 'multi-broker-kafka-zk'
       CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092,broker1:29092,broker2:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
       CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
       CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
-      CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
-      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
+      CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
+      CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
       CDK_MONITORING_NOTIFICATIONS-CALLBACK-URL: http://localhost:8080
       CDK_LISTENING_PORT: 8080
@@ -243,7 +243,7 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metadata:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -271,8 +271,9 @@ services:
       retries: 5
     restart: on-failure:5
 
-  conduktor-monitoring:
-    image: *conduktor-monitoring-image
+  conduktor-cortex:
+    image: *conduktor-cortex-image
+    container_name: conduktor-cortex
     environment:
       CDK_CONSOLE-URL: "http://conduktor-console:8080"
     ports:
@@ -282,9 +283,19 @@ services:
     restart: on-failure:5
 
 volumes:
+  vol-zk-data:
+    name: vol-zk-data
+  vol-zk-logs:
+    name: vol-zk-logs
+  vol-kafka-broker0:
+      name: vol-kafka-broker0
+  vol-kafka-broker1:
+      name: vol-kafka-broker1
+  vol-kafka-broker2:
+      name: vol-kafka-broker2
   vol-conduktor-data:
     name: vol-conduktor-data
-  vol-conduktor-metadata:
-    name: vol-conduktor-metadata
+  vol-conduktor-metastore:
+    name: vol-conduktor-metastore
   vol-conduktor-sql:
     name: vol-conduktor-sql

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -1,9 +1,9 @@
-x-cp-zookeeper-image: &cp-zookeeper-image confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
-x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.7.2}
+x-cp-zookeeper-image: &cp-zookeeper-image confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-kafka-image: &cp-kafka-image confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-schema-registry-image: &cp-schema-registry-image confluentinc/cp-schema-registry:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-rest-proxy-image: &cp-restproxy-image confluentinc/cp-kafka-rest:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
+x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUENT_PLATFORM_VERSION:-7.8.0}
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}
 x-conduktor-monitoring: &conduktor-monitoring-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.29.1}

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -157,7 +157,7 @@ services:
     ports:
       - '8088:8088'
     volumes:
-      - ${KSQL_UDF_EXTENSIONS_DIR:-./volumes/ksqldb-udf}:/opt/ksqldb-udf
+      - vol-ksqldb-udf:/opt/ksqldb-udf
     depends_on:
       <<: *depends-on-kafka-cluster
     healthcheck:
@@ -293,6 +293,8 @@ volumes:
       name: vol-kafka-broker1
   vol-kafka-broker2:
       name: vol-kafka-broker2
+  vol-ksqldb-udf:
+    name: vol-ksqldb-udf
   vol-conduktor-data:
     name: vol-conduktor-data
   vol-conduktor-metastore:

--- a/module6-stream-processing/kotlin/README.md
+++ b/module6-stream-processing/kotlin/README.md
@@ -1,6 +1,6 @@
 # Stream processing with Kafka, ksqlDB and Kotlin
 
-![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.7-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
+![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.8-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.0-603DC0.svg?style=flat&logo=kotlin&logoColor=white&labelColor=603DC0)
 ![JDK](https://img.shields.io/badge/JDK-21_|_17_|_11-3F90BD.svg?style=flat&logo=openjdk&logoColor=white&labelColor=3F90BD)
 ![Gradle](https://img.shields.io/badge/gradle-8.5-02303A?style=flat&logo=gradle&logoColor=white&labelColor=02303A)

--- a/module6-stream-processing/ksqldb/README.md
+++ b/module6-stream-processing/ksqldb/README.md
@@ -1,6 +1,6 @@
 # Kafka Streams with ksqlDB
 
-![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.7-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
+![Kafka](https://img.shields.io/badge/Confluent_Kafka-7.8-141414?style=flat&logo=apachekafka&logoColor=white&labelColor=141414)
 ![Docker](https://img.shields.io/badge/Docker-329DEE?style=flat&logo=docker&logoColor=white&labelColor=329DEE)
 
 ![License](https://img.shields.io/badge/license-CC--BY--SA--4.0-31393F?style=flat&logo=creativecommons&logoColor=black&labelColor=white)


### PR DESCRIPTION
## Summary

* Update Kafka Brokers & ZooKeeper to use Docker Volumes instead
* Update ksqldb0 volume to use Docker volumes instead
* Update conduktor-monitoring container name to `conduktor-cortex`
* Bumps confluent-platform to 7.8.0
* Update GitHub shields