### PR TITLE
refactor/pyspark3.5: Upgrade Spark Docker Image and subproject to 3.5.8

### DIFF
--- a/module5-batch-processing/compose.spark-3.5-standalone.yaml
+++ b/module5-batch-processing/compose.spark-3.5-standalone.yaml
@@ -1,4 +1,4 @@
-x-spark-image: &spark-image spark:${SPARK_VERSION:-3.5.7-scala2.12-java17-python3-ubuntu}
+x-spark-image: &spark-image apache/spark:${SPARK_VERSION:-3.5.8-scala2.12-java17-python3-ubuntu}
 
 x-spark-common:
   &spark-common

--- a/module5-batch-processing/pyspark-3.x/pyproject.toml
+++ b/module5-batch-processing/pyspark-3.x/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 
 dependencies = [
-    "pyspark[connect]==3.5.7,<4.0",
+    "pyspark[connect]==3.5.8,<4.0",
     "pyarrow>=23.0.0,<24.0",
 ]
 

--- a/module5-batch-processing/pyspark-3.x/uv.lock
+++ b/module5-batch-processing/pyspark-3.x/uv.lock
@@ -1094,12 +1094,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.7"
+version = "3.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/65/2764b1840aa6ea5f7e668a36702c3128ac54d0b861d3d57669b2453469a6/pyspark-3.5.7.tar.gz", hash = "sha256:80e36514e0c5c126d35a26adf4f405cd4a69de96a8ea8a3c1e9a65fce2fb4eaa", size = 317370347, upload-time = "2025-09-23T19:46:10.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz", hash = "sha256:54cca0767b21b40e3953ad1d30f8601c53abf9cbda763653289cdcfcac52313c", size = 317817299, upload-time = "2026-01-15T11:46:14.487Z" }
 
 [package.optional-dependencies]
 connect = [
@@ -1129,7 +1129,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pyarrow", specifier = ">=23.0.0,<24.0" },
-    { name = "pyspark", extras = ["connect"], specifier = "==3.5.7,<4.0" },
+    { name = "pyspark", extras = ["connect"], specifier = "==3.5.8,<4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
* Updates Spark image to `apache/spark:3.5.8`
* Bumps `pyspark` dependency in `pyspark-pipeline` to 3.5.8 to match Spark Cluster

## Test plan
- [x] Verify Spark standalone cluster starts with the updated image
- [x] Run PySpark pipeline against the updated cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)