### PR TITLE
fix/airflow2-pgsql-mount: Fix Postgres volume mount and healthcheck for postgres:18-alpine+

### DIFF
--- a/module2-workflow-orchestration/airflow-2.x/compose.celery.yaml
+++ b/module2-workflow-orchestration/airflow-2.x/compose.celery.yaml
@@ -1,4 +1,4 @@
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 x-redis-image: &redis-image redis:${REDIS_VERSION:-8.4-alpine}
 
 x-airflow-common:

--- a/module2-workflow-orchestration/airflow-2.x/compose.celery.yaml
+++ b/module2-workflow-orchestration/airflow-2.x/compose.celery.yaml
@@ -52,9 +52,9 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - vol-ingest-db:/var/lib/postgresql/data
+      - vol-ingest-db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -70,9 +70,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-airflow-metastore-celeryexec:/var/lib/postgresql/data
+      - vol-airflow-metastore-celeryexec:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/module2-workflow-orchestration/airflow-2.x/compose.local.yaml
+++ b/module2-workflow-orchestration/airflow-2.x/compose.local.yaml
@@ -46,9 +46,9 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - vol-ingest-db:/var/lib/postgresql/data
+      - vol-ingest-db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -64,9 +64,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-airflow-metastore-localexec:/var/lib/postgresql/data
+      - vol-airflow-metastore-localexec:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/module2-workflow-orchestration/airflow-2.x/compose.local.yaml
+++ b/module2-workflow-orchestration/airflow-2.x/compose.local.yaml
@@ -1,4 +1,4 @@
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 x-airflow-common:
   &airflow-common


### PR DESCRIPTION
## Summary
* Fix volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
   to avoid breakage due to PGDATA change in postgres:18-alpine+
* Use `$$POSTGRES_USER` env var in healthcheck instead of hardcoded username
* Pin default image tag to `postgres:18-alpine` floating tag

This addresses a breaking change introduced in [docker-library/postgres#1394](https://github.com/docker-library/postgres/pull/1394).

## Test plan
- [x] `docker compose -f compose.local.yaml up` starts successfully with healthy postgres services
- [x] `docker compose -f compose.celery.yaml up` starts successfully with healthy postgres services
- [x] Verify healthchecks pass for both `tlc-db` and `airflow-metastore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)