### PR TITLE
fix/hive-pgsql: Fix Postgres config for Hive Metastore DB

### DIFF
--- a/module5-batch-processing/compose.spark-4.1-standalone.yaml
+++ b/module5-batch-processing/compose.spark-4.1-standalone.yaml
@@ -109,9 +109,9 @@ services:
     ports:
       - '5433:5432'
     volumes:
-      - vol-hive-db:/var/lib/postgresql/data
+      - vol-hive-db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module5-batch-processing/compose.spark-4.1-standalone.yaml
+++ b/module5-batch-processing/compose.spark-4.1-standalone.yaml
@@ -103,8 +103,8 @@ services:
     image: *postgres-image
     container_name: hive-metastore-db
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_USER: 'hive'
+      POSTGRES_PASSWORD: 'hive'
       POSTGRES_DB: 'metastore'
     ports:
       - '5433:5432'
@@ -125,8 +125,8 @@ services:
       SERVICE_OPTS: |-
         -Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver
         -Djavax.jdo.option.ConnectionURL=jdbc:postgresql://hive-db:5432/metastore
-        -Djavax.jdo.option.ConnectionUserName=postgres
-        -Djavax.jdo.option.ConnectionPassword=postgres
+        -Djavax.jdo.option.ConnectionUserName=hive
+        -Djavax.jdo.option.ConnectionPassword=hive
       HIVE_AUX_JARS_PATH: /opt/hive/aux_jars/
       DB_DRIVER: 'postgres'
     ports:

--- a/module5-batch-processing/compose.spark-4.1-standalone.yaml
+++ b/module5-batch-processing/compose.spark-4.1-standalone.yaml
@@ -1,6 +1,6 @@
 x-spark-image: &spark-image apache/spark:${SPARK_VERSION:-4.1.1-scala2.13-java21-python3-ubuntu}
 x-hive-image:  &hive-image  apache/hive:${HIVE_VERSION:-4.2.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 x-spark-common:
   &spark-common


### PR DESCRIPTION
## Summary
* Fix volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
   to avoid breakage due to PGDATA change in postgres:18-alpine+
* Use `$$POSTGRES_USER` env var in healthcheck instead of hardcoded username
* Pin default image tag to `postgres:18-alpine` floating tag
* Update Hive metastore DB credentials to use dedicated `hive` user instead of default `postgres`

This addresses a breaking change introduced in [docker-library/postgres#1394](https://github.com/docker-library/postgres/pull/1394).

## Test plan
- [ ] Verify `hive-db` container starts and initializes with the `hive` user
- [ ] Verify `hive-metastore` connects successfully to the database
- [ ] Verify healthcheck passes using `$$POSTGRES_USER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)