### PR TITLE
fix/dbt-postgres: Fix postgres volume mount for 18-alpine

### DIFF
--- a/module4-analytics-engineering/postgres/compose.yaml
+++ b/module4-analytics-engineering/postgres/compose.yaml
@@ -11,9 +11,9 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - vol-ingest-db:/var/lib/postgresql/data
+      - vol-ingest-db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module4-analytics-engineering/postgres/compose.yaml
+++ b/module4-analytics-engineering/postgres/compose.yaml
@@ -1,4 +1,4 @@
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 services:
   ingest-db:


### PR DESCRIPTION
## Summary
* Fix volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
   to avoid breakage due to PGDATA change in postgres:18-alpine+
* Use `$$POSTGRES_USER` env var in healthcheck instead of hardcoded username
* Upgrade default Postgres image from `17-alpine` to `18-alpine`

This addresses a breaking change introduced in [docker-library/postgres#1394](https://github.com/docker-library/postgres/pull/1394).

## Test plan
- [x] Run `docker compose up` and verify the postgres container starts and passes healthcheck
- [x] Verify data is persisted in the volume correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)