### PR TITLE
fix/conduktor-pgsql: Fix Postgres config for postgres:18-alpine

### DIFF
--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -192,8 +192,8 @@ services:
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
-      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
+      CDK_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-sql:5432/conduktor_sql"
       CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
       CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
@@ -216,8 +216,8 @@ services:
     container_name: conduktor-metastore
     hostname: conduktor-metastore
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
       POSTGRES_DB: 'conduktor'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
@@ -236,9 +236,9 @@ services:
     container_name: conduktor-sql
     hostname: conduktor-sql
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
-      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
+      POSTGRES_DB: 'conduktor_sql'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
       - '5432'

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -5,7 +5,7 @@ x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
 x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 x-kafka-common:
   &kafka-common

--- a/module6-stream-processing/compose.kraft-multi-broker.yaml
+++ b/module6-stream-processing/compose.kraft-multi-broker.yaml
@@ -223,9 +223,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metastore:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -243,9 +243,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-sql:/var/lib/postgresql/data
+      - vol-conduktor-sql:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -187,9 +187,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metastore:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -207,9 +207,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-sql:/var/lib/postgresql/data
+      - vol-conduktor-sql:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -5,7 +5,7 @@ x-cp-ksqldb-server-image: &cp-ksqldb-server-image confluentinc/cp-ksqldb-server:
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
 x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 x-kafka-common:
   &kafka-common

--- a/module6-stream-processing/compose.kraft-single-broker.yaml
+++ b/module6-stream-processing/compose.kraft-single-broker.yaml
@@ -156,8 +156,8 @@ services:
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
-      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
+      CDK_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-sql:5432/conduktor_sql"
       CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
       CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
@@ -180,8 +180,8 @@ services:
     container_name: conduktor-metastore
     hostname: conduktor-metastore
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
       POSTGRES_DB: 'conduktor'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
@@ -200,9 +200,9 @@ services:
     container_name: conduktor-sql
     hostname: conduktor-sql
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
-      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
+      POSTGRES_DB: 'conduktor_sql'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
       - '5432'

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -2,7 +2,7 @@ x-redpanda-image: &redpanda-image redpandadata/redpanda:${REDPANDA_VERSION:-v25.
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
 x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 services:
   broker0:

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -69,9 +69,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metastore:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -89,9 +89,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-sql:/var/lib/postgresql/data
+      - vol-conduktor-sql:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module6-stream-processing/compose.redpanda.yaml
+++ b/module6-stream-processing/compose.redpanda.yaml
@@ -41,8 +41,8 @@ services:
       CDK_CLUSTERS_0_NAME: 'single-broker-redpanda'
       CDK_CLUSTERS_0_BOOTSTRAPSERVERS: 'broker0:29092'
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://broker0:8081'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
-      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
+      CDK_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-sql:5432/conduktor_sql"
       CDK_MONITORING_CORTEX-URL: http://conduktor-monitoring:9009/
       CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-monitoring:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
@@ -62,8 +62,8 @@ services:
     container_name: conduktor-metastore
     hostname: conduktor-metastore
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
       POSTGRES_DB: 'conduktor'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
@@ -82,9 +82,9 @@ services:
     container_name: conduktor-sql
     hostname: conduktor-sql
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
-      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
+      POSTGRES_DB: 'conduktor_sql'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
       - '5432'

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -7,7 +7,7 @@ x-cp-ksqldb-cli-image: &cp-ksqldb-cli-image confluentinc/cp-ksqldb-cli:${CONFLUE
 
 x-conduktor-console: &conduktor-console-image conduktor/conduktor-console:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
 x-conduktor-cortex: &conduktor-cortex-image conduktor/conduktor-console-cortex:${CONDUKTOR_PLATFORM_VERSION:-1.42.0}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18.1-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 x-kafka-common:
   &kafka-common

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -244,9 +244,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-metastore:/var/lib/postgresql/data
+      - vol-conduktor-metastore:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -264,9 +264,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-conduktor-sql:/var/lib/postgresql/data
+      - vol-conduktor-sql:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/module6-stream-processing/compose.zookeeper-multi-broker.yaml
+++ b/module6-stream-processing/compose.zookeeper-multi-broker.yaml
@@ -213,8 +213,8 @@ services:
       CDK_CLUSTERS_0_SCHEMAREGISTRY_URL: 'http://schema-registry:8081'
       CDK_CLUSTERS_0_KSQLDBS_0_NAME: 'ksqldb0'
       CDK_CLUSTERS_0_KSQLDBS_0_URL: 'http://ksqldb0:8088'
-      CDK_DATABASE_URL: "postgresql://postgres:postgres@conduktor-metastore:5432/conduktor"
-      CDK_KAFKASQL_DATABASE_URL: "postgresql://postgres:postgres@conduktor-sql:5432/conduktor-sql"
+      CDK_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-metastore:5432/conduktor"
+      CDK_KAFKASQL_DATABASE_URL: "postgresql://conduktor:conduktor@conduktor-sql:5432/conduktor_sql"
       CDK_MONITORING_CORTEX-URL: http://conduktor-cortex:9009/
       CDK_MONITORING_ALERT-MANAGER-URL: http://conduktor-cortex:9010/
       CDK_MONITORING_CALLBACK-URL: http://conduktor-console:8080/monitoring/api/
@@ -237,8 +237,8 @@ services:
     container_name: conduktor-metastore
     hostname: conduktor-metastore
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
       POSTGRES_DB: 'conduktor'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
@@ -257,9 +257,9 @@ services:
     container_name: conduktor-sql
     hostname: conduktor-sql
     environment:
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'postgres'
-      POSTGRES_DB: 'conduktor-sql'
+      POSTGRES_USER: 'conduktor'
+      POSTGRES_PASSWORD: 'conduktor'
+      POSTGRES_DB: 'conduktor_sql'
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     ports:
       - '5432'


### PR DESCRIPTION
## Summary
* Fix volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
   to avoid breakage due to PGDATA change in postgres:18-alpine+
* Use `$$POSTGRES_USER` env var in healthcheck instead of hardcoded username
* Pin default image tag to `postgres:18-alpine` floating tag
* Updates Postgres credentials to `conduktor`/`conduktor` for both services
* Rename `conduktor-sql` database to `conduktor_sql`

This addresses a breaking change introduced in [docker-library/postgres#1394](https://github.com/docker-library/postgres/pull/1394).

## Test plan
- [x] Verify `conduktor-metastore` and `conduktor-sql` services start correctly with all 4 compose files
- [x] Verify Conduktor Console connects successfully to both databases
- [x] Verify healthchecks pass with the `$$POSTGRES_USER` env var resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)