### PR TITLE
fix/prefect-pgsql-mount: Fix Postgres volume mount, healthcheck and upgrade to 18-alpine

### DIFF
--- a/module2-workflow-orchestration/prefect/README.md
+++ b/module2-workflow-orchestration/prefect/README.md
@@ -47,7 +47,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcs_credentials.json
 
 Then, execute with:
 ```shell
-python flows/web_cs_to_gcs.py
+python flows/web_csv_to_gcs.py
 ```
 
 #### flows/sqlalchemy_ingest.py:

--- a/module2-workflow-orchestration/prefect/compose.yaml
+++ b/module2-workflow-orchestration/prefect/compose.yaml
@@ -1,5 +1,5 @@
 x-prefect-image:  &prefect-image prefecthq/prefect:${PREFECT_VERSION:-3.1.15-python3.12-kubernetes}
-x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-17-alpine}
+x-postgres-image: &postgres-image postgres:${POSTGRES_VERSION:-18-alpine}
 
 services:
   ingest-db:

--- a/module2-workflow-orchestration/prefect/compose.yaml
+++ b/module2-workflow-orchestration/prefect/compose.yaml
@@ -12,9 +12,9 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - vol-ingest-db:/var/lib/postgresql/data
+      - vol-ingest-db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -30,9 +30,9 @@ services:
     ports:
       - '5432'
     volumes:
-      - vol-prefect-metastore:/var/lib/postgresql/data
+      - vol-prefect-metastore:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U prefect"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
* Fix volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
   to avoid breakage due to PGDATA change in postgres:18-alpine+
* Use `$$POSTGRES_USER` env var in healthcheck instead of hardcoded username
* Upgrade default Postgres image from `17-alpine` to `18-alpine`

This addresses a breaking change introduced in [docker-library/postgres#1394](https://github.com/docker-library/postgres/pull/1394).

## Test plan
- [x] Run `docker compose up` and verify both `ingest-db` and `prefect-metastore` start and pass healthchecks
- [x] Verify data persistence across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)