### PR TITLE
refactor/dbt-redshift: IAM auth setup for dbt-redshift profiles

### DIFF
--- a/module4-analytics-engineering/redshift/README.md
+++ b/module4-analytics-engineering/redshift/README.md
@@ -11,7 +11,7 @@ This project is meant for experimenting with `dbt` and the `dbt-redshift` adapte
 using [NYC TLC Trip Record](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) dataset as the datasource, with Kimball dimensional modeling technique.
 
 
-**IMPORTANT NOTE**: By default, a Redshift Serverless workgroup is only reachable from within its VPC. If you're running `dbt` from outside of it (e.g. your local machine) and get a connection timeout, you'll need to temporarily:
+**IMPORTANT NOTE**: By default, a Redshift is only reachable from within its VPC. If you're running `dbt` from outside of it (e.g. your local machine) and get a connection timeout, you'll need to temporarily:
 
 1. On the workgroup's network settings, toggle **Publicly accessible** on
 2. On its VPC security group, add an inbound rule for **Redshift (TCP 5439)** with source **My IP** (avoid `0.0.0.0/0`)
@@ -44,9 +44,9 @@ cat profiles.redshift-serverless.yml >> ~/.dbt/profiles.yml
 
 3.2a. Set the env variables for `dbt-redshift` (Redshift Serverless): 
 ```shell
-export DBT_REDSHIFT_HOST=[workgroup_name].[account_id].[region].redshift-serverless.amazonaws.com
-export DBT_REDSHIFT_USE_DATA_CATALOG=1
-export DBT_REDSHIFT_SOURCE_SCHEMA=nyc_tlc_raw
+export DBT_REDSHIFT_HOST=[endpoint]
+export DBT_REDSHIFT_SOURCE_DATABASE=dev
+export DBT_REDSHIFT_SOURCE_SCHEMA=nyc_tlc_ext
 export DBT_REDSHIFT_TARGET_DATABASE=dev
 export DBT_REDSHIFT_TARGET_SCHEMA=nyc_tlc_trip_data
 export DBT_REDSHIFT_IAM_PROFILE=iobruno-aws-labs
@@ -54,15 +54,15 @@ export DBT_REDSHIFT_IAM_PROFILE=iobruno-aws-labs
 
 
 3.2b. Set the env vars for `dbt-redshift` (Redshift Provisioned)
-
 ```shell
-export DBT_REDSHIFT_HOST=redshift.[id].[region].redshift-serverless.amazonaws.com
-export DBT_REDSHIFT_CLUSTER_ID=
-export DBT_REDSHIFT_DATABASE=dev
-export DBT_REDSHIFT_USE_DATA_CATALOG=1
-export DBT_REDSHIFT_SOURCE_GLUE_CATALOG_DB=raw_nyc_tlc_tripdata
+export DBT_REDSHIFT_HOST=[endpoint]
+export DBT_REDSHIFT_CLUSTER_ID=[cluster_id]
+export DBT_REDSHIFT_SOURCE_DATABASE=dev
+export DBT_REDSHIFT_SOURCE_SCHEMA=nyc_tlc_ext
+export DBT_REDSHIFT_TARGET_DATABASE=dev
 export DBT_REDSHIFT_TARGET_SCHEMA=nyc_tlc_record_data
-export DBT_REDSHIFT_IAM_PROFILE=
+export DBT_REDSHIFT_IAM_PROFILE=iobruno-aws-labs
+export DBT_REDSHIFT_USER=<iam_user_if_group_federation_else_db_user>
 ```
 
 **4.** Install dbt dependencies and trigger the pipeline

--- a/module4-analytics-engineering/redshift/models/staging/sources.yml
+++ b/module4-analytics-engineering/redshift/models/staging/sources.yml
@@ -2,12 +2,7 @@ version: 2
 
 sources:
   - name: raw_nyc_tlc_record_data
-    database: |-
-      {%- if env_var('DBT_REDSHIFT_USE_DATA_CATALOG', 0) == '1' -%}
-        awsdatacatalog
-      {%- else -%}
-        {{ env_var('DBT_REDSHIFT_SOURCE_DATABASE') }}
-      {%- endif -%}
+    database: "{{ env_var('DBT_REDSHIFT_SOURCE_DATABASE') }}"
 
     # IMPORTANT: When the source is Glue Data Catalog, `schema` must match the Glue
     # Database name, and each entry in `tables` must match an actual table name

--- a/module4-analytics-engineering/redshift/profiles.redshift.yml
+++ b/module4-analytics-engineering/redshift/profiles.redshift.yml
@@ -8,8 +8,10 @@ dbt_redshift_analytics:
       cluster_id:   "{{ env_var('DBT_REDSHIFT_CLUSTER_ID') }}"
       dbname:       "{{ env_var('DBT_REDSHIFT_TARGET_DATABASE') }}"
       schema:       "{{ env_var('DBT_REDSHIFT_TARGET_SCHEMA') }}"
-      user:         "{{ env_var('DBT_REDSHIFT_USER', 'dbt_redshift') }}"  # db_user must be created
-      iam_profile:  "{{ env_var('DBT_REDSHIFT_IAM_PROFILE') }}"           # reads profile defined in ~/.aws/credentials
+      iam_profile:  "{{ env_var('DBT_REDSHIFT_IAM_PROFILE') }}"   # reads profile defined in ~/.aws/credentials
+      user:         "{{ env_var('DBT_REDSHIFT_USER') }}"
+      group_federation: true                                      # logs in as IAM:<user> — must be a valid IAM identity
+      # group_federation: false                                   # logs in as <user> — an existing DB user; create via CREATE USER <user> PASSWORD '<pwd>' (pwd unused under IAM auth)
       threads: 4
 
     prod:
@@ -20,8 +22,10 @@ dbt_redshift_analytics:
       cluster_id:   "{{ env_var('DBT_REDSHIFT_CLUSTER_ID') }}"
       dbname:       "{{ env_var('DBT_REDSHIFT_TARGET_DATABASE') }}"
       schema:       "{{ env_var('DBT_REDSHIFT_TARGET_SCHEMA') }}"
-      user:         "{{ env_var('DBT_REDSHIFT_USER', 'dbt_redshift') }}" # db_user must be created 
-      iam_profile:  "{{ env_var('DBT_REDSHIFT_IAM_PROFILE') }}"          # reads profile defined in ~/.aws/credentials
+      iam_profile:  "{{ env_var('DBT_REDSHIFT_IAM_PROFILE') }}"   # reads profile defined in ~/.aws/credentials
+      user:         "{{ env_var('DBT_REDSHIFT_USER') }}"
+      group_federation: true                                      # logs in as IAM:<user> — must be a valid IAM identity
+      # group_federation: false                                   # logs in as <user> — an existing DB user; create via CREATE USER <user> PASSWORD '<pwd>' (pwd unused under IAM auth)
       threads: 4
 
   target: dev


### PR DESCRIPTION
## Summary

* Simplify `sources.yml` to always read from `DBT_REDSHIFT_SOURCE_DATABASE`, 
   dropping the `DBT_REDSHIFT_USE_DATA_CATALOG`/`awsdatacatalog` conditional branch
* Update `profiles.redshift.yml` to support IAM auth via either group federation (`IAM:<user>`)
   or a plain `db_user`, controlled by a new `group_federation` flag
* Update the README's running instructions to match: corrected env var examples for 
   both Redshift Serverless and Provisioned setups

## Test plan
- [x] Run `dbt debug` against a Redshift Serverless workgroup with `group_federation: true` (`IAM:<user>`)
- [x] Run `dbt debug` against a Redshift Serverless workgroup with `group_federation: false` and a pre-created `db_user`
- [x] Run `dbt build` end-to-end against a provisioned cluster following the updated README instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)